### PR TITLE
fix character card

### DIFF
--- a/client/Assets/Prefabs/CharacterCard.prefab
+++ b/client/Assets/Prefabs/CharacterCard.prefab
@@ -84,7 +84,7 @@ MonoBehaviour:
   m_FallbackScreenDPI: 96
   m_DefaultSpriteDPI: 96
   m_DynamicPixelsPerUnit: 1
-  m_PresetInfoIsWorld: 0
+  m_PresetInfoIsWorld: 1
 --- !u!114 &4738216627854206166
 MonoBehaviour:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
## Motivation

Unity is throwing a ton of errors when Muflus attacks.

## Summary of changes

Update CharacterCard.prefab

