### PR TITLE
Bug fix for character card prefab

### DIFF
--- a/client/Assets/Prefabs/CharacterCard.prefab
+++ b/client/Assets/Prefabs/CharacterCard.prefab
@@ -10,7 +10,6 @@ GameObject:
   m_Component:
   - component: {fileID: 8206914607531316031}
   - component: {fileID: 6275522562409476376}
-  - component: {fileID: 2630530166730011964}
   - component: {fileID: 4738216627854206166}
   m_Layer: 0
   m_Name: CharacterCard
@@ -62,29 +61,6 @@ Canvas:
   m_SortingLayerID: 0
   m_SortingOrder: 0
   m_TargetDisplay: 0
---- !u!114 &2630530166730011964
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1428990921056839056}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_UiScaleMode: 0
-  m_ReferencePixelsPerUnit: 100
-  m_ScaleFactor: 1
-  m_ReferenceResolution: {x: 800, y: 600}
-  m_ScreenMatchMode: 0
-  m_MatchWidthOrHeight: 0
-  m_PhysicalUnit: 3
-  m_FallbackScreenDPI: 96
-  m_DefaultSpriteDPI: 96
-  m_DynamicPixelsPerUnit: 1
-  m_PresetInfoIsWorld: 0
 --- !u!114 &4738216627854206166
 MonoBehaviour:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
## Motivation

This prefab if open by a dev was changing to the oposite value of `m_PresetInfoIsWorld` from it was set to. This was because of a component that should not have been applied there called `CanvasScaler`

## Summary of changes

This PR deletes that component and fixes the bug. To test this works correctly I recommend starting a match and checking the health bars and names from every player are not distorted when moving them around

To test this worked the reviewer should be able to open the CharacterCard prefab and have no changes made by this

## Checklist
- [x] I have tested the changes locally.
- [ ] I self-reviewed the changes on GitHub, line by line.
- [ ] Tests have been added/updated.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] I have tested the changes in another devices.
  - [ ] Tested in iOS.
  - [ ] Tested in Android.
