### PR TITLE
Start using items from new game state and stop protobuf class usage

### DIFF
--- a/client/Assets/Scripts/Battle.cs
+++ b/client/Assets/Scripts/Battle.cs
@@ -369,7 +369,7 @@ public class Battle : MonoBehaviour
         GameObject projectile;
         for (int i = 0; i < gameProjectiles.Count; i++)
         {
-            Vector3 backToFrontPosition = Utils.transformBackendPositionToFrontendPosition(
+            Vector3 backToFrontPosition = Utils.transformBackendOldPositionToFrontendPosition(
                 gameProjectiles[i].Position
             );
             if (projectiles.TryGetValue((int)gameProjectiles[i].Id, out projectile))
@@ -534,7 +534,7 @@ public class Battle : MonoBehaviour
         float tickRate = 1000f / SocketConnectionManager.Instance.serverTickRate_ms;
         float velocity = tickRate * characterSpeed;
 
-        var frontendPosition = Utils.transformBackendPositionToFrontendPosition(
+        var frontendPosition = Utils.transformBackendOldPositionToFrontendPosition(
             playerUpdate.Position
         );
 

--- a/client/Assets/Scripts/CustomLevelManager.cs
+++ b/client/Assets/Scripts/CustomLevelManager.cs
@@ -175,7 +175,7 @@ public class CustomLevelManager : LevelManager
             }
             CustomCharacter newPlayer = Instantiate(
                 prefab.GetComponent<CustomCharacter>(),
-                Utils.transformBackendPositionToFrontendPosition(gamePlayers[(int)i].Position),
+                Utils.transformBackendOldPositionToFrontendPosition(gamePlayers[(int)i].Position),
                 Quaternion.identity
             );
             newPlayer.name = "Player" + " " + (i + 1);

--- a/client/Assets/Scripts/Game/GameState.cs
+++ b/client/Assets/Scripts/Game/GameState.cs
@@ -10,7 +10,7 @@ namespace Game {
         private long serverTimestamp { get; }
         private List<Player> players { get; }
         private List<Projectile> projectiles { get; }
-        private List<Item> items { get; }
+        public List<Item> items { get; }
         private List<KillEvent> killfeed { get; }
 
         public GameState(Communication.Protobuf.GameState protobufGameState) {

--- a/client/Assets/Scripts/Game/Item.cs
+++ b/client/Assets/Scripts/Game/Item.cs
@@ -2,10 +2,10 @@ namespace Game {
     using Communication.Protobuf;
 
     public class Item {
-        private ulong id { get; }
-        private string name { get; }
-        private float size { get; }
-        private Position position { get; }
+        public ulong id { get; }
+        public string name { get; }
+        public float size { get; }
+        public Position position { get; }
 
         public Item(Communication.Protobuf.Item protobufItem) {
             this.id = protobufItem.Id;

--- a/client/Assets/Scripts/Game/Position.cs
+++ b/client/Assets/Scripts/Game/Position.cs
@@ -2,8 +2,8 @@ namespace Game {
     using Communication.Protobuf;
 
     public class Position {
-        private float x { get; }
-        private float y { get; }
+        public float x { get; }
+        public float y { get; }
 
         public Position(float x, float y) {
             this.x = x;
@@ -12,7 +12,7 @@ namespace Game {
 
         public Position(Communication.Protobuf.Position protobufPosition) {
             this.x = protobufPosition.X;
-            this.y = protobufPosition.X;
+            this.y = protobufPosition.Y;
         }
     }
 }

--- a/client/Assets/Scripts/Loot.cs
+++ b/client/Assets/Scripts/Loot.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using MoreMountains.Tools;
 using UnityEngine;
-using Communication.Protobuf;
+using Game;
 
 public class Loot : MonoBehaviour
 {
@@ -36,31 +36,31 @@ public class Loot : MonoBehaviour
         }
     }
 
-    private void MaybeAddLoot(LootPackage loot)
+    private void MaybeAddLoot(Item item)
     {
-        if (!ExistInLoots(loot.Id))
+        if (!ExistInLoots(item.id))
         {
-            var position = Utils.transformBackendPositionToFrontendPosition(loot.Position);
+            var position = Utils.transformBackendPositionToFrontendPosition(item.position);
             position.y = 0;
             LootItem LootItem = new LootItem();
             LootItem.lootObject = objectPooler.GetPooledGameObject();
             LootItem.lootObject.transform.position = position;
-            LootItem.lootObject.name = loot.Id.ToString();
+            LootItem.lootObject.name = item.id.ToString();
             LootItem.lootObject.transform.rotation = Quaternion.identity;
             LootItem.lootObject.SetActive(true);
-            LootItem.id = loot.Id;
-            LootItem.type = loot.LootType.ToString();
+            LootItem.id = item.id;
+            LootItem.type = convertItemNameToType(item.name);
             loots.Add(LootItem);
         }
     }
 
-    private void RemoveLoots(List<LootPackage> updatedLoots)
+    private void RemoveLoots(List<Item> updatedLoots)
     {
         loots
             .ToList()
             .ForEach(loot =>
             {
-                if (!updatedLoots.Exists(lootPackage => lootPackage.Id == loot.id))
+                if (!updatedLoots.Exists(lootPackage => lootPackage.id == loot.id))
                 {
                     RemoveLoot(loot.id);
                 }
@@ -116,8 +116,15 @@ public class Loot : MonoBehaviour
 
     public void UpdateLoots()
     {
-        List<LootPackage> updatedLoots = SocketConnectionManager.Instance.updatedLoots;
+        List<Item> updatedLoots = SocketConnectionManager.Instance.gameState.items;
         RemoveLoots(updatedLoots);
         updatedLoots.ForEach(MaybeAddLoot);
+    }
+
+    private string convertItemNameToType(string name) {
+        switch (name) {
+            case "loot_health": return "LootHealth";
+            default: throw new ArgumentException(String.Format("no type for `{0}`", name));
+        }
     }
 }

--- a/client/Assets/Scripts/SocketConnectionManager.cs
+++ b/client/Assets/Scripts/SocketConnectionManager.cs
@@ -46,7 +46,6 @@ public class SocketConnectionManager : MonoBehaviour
     public OldPosition shrinkingCenter;
 
     public List<OldPlayer> alivePlayers = new List<OldPlayer>();
-    public List<LootPackage> updatedLoots = new List<LootPackage>();
 
     public bool cinematicDone;
 
@@ -202,7 +201,6 @@ public class SocketConnectionManager : MonoBehaviour
                     alivePlayers = gameEvent.OldGameEvent.Players
                         .ToList()
                         .FindAll(el => el.Health > 0);
-                    updatedLoots = gameEvent.OldGameEvent.Loots.ToList();
                     KillFeedManager.instance.putEvents(gameEvent.OldGameEvent.Killfeed.ToList());
                     break;
                 case GameEventType.PingUpdate:

--- a/client/Assets/Scripts/SocketConnectionManager.cs
+++ b/client/Assets/Scripts/SocketConnectionManager.cs
@@ -52,6 +52,8 @@ public class SocketConnectionManager : MonoBehaviour
 
     public bool connected = false;
 
+    public Game.GameState gameState;
+
     WebSocket ws;
 
     private string clientId;
@@ -167,6 +169,28 @@ public class SocketConnectionManager : MonoBehaviour
         try
         {
             TransitionGameEvent gameEvent = TransitionGameEvent.Parser.ParseFrom(data);
+
+            // TODO: Fix missing NewGameEvent, current missing are
+            //      - PING_UPDATE
+            //      - PLAYER_JOINED
+            if (gameEvent.OldGameEvent.Type != GameEventType.PingUpdate
+                && gameEvent.OldGameEvent.Type != GameEventType.PlayerJoined) {
+                try {
+                    switch (gameEvent.NewGameEvent.EventCase) {
+                        case GameEvent.EventOneofCase.GameState:
+                            gameState = new Game.GameState(gameEvent.NewGameEvent.GameState);
+                            break;
+                        default:
+                            print("Unexpected message: " + gameEvent.NewGameEvent.EventCase);
+                            break;
+                    }
+                } catch (Exception e) {
+                    Debug.Log(gameEvent);
+                    Debug.Log(e);
+                    throw e;
+                }
+            }
+
             switch (gameEvent.OldGameEvent.Type)
             {
                 case GameEventType.StateUpdate:

--- a/client/Assets/Scripts/UI/SafeZone.cs
+++ b/client/Assets/Scripts/UI/SafeZone.cs
@@ -15,7 +15,7 @@ public class SafeZone : MonoBehaviour
                 SocketConnectionManager.Instance.playableRadius
             );
 
-            Vector3 center = Utils.transformBackendPositionToFrontendPosition(
+            Vector3 center = Utils.transformBackendOldPositionToFrontendPosition(
                 SocketConnectionManager.Instance.shrinkingCenter
             );
 

--- a/client/Assets/Scripts/Utils/Utils.cs
+++ b/client/Assets/Scripts/Utils/Utils.cs
@@ -21,10 +21,17 @@ public class Utils
         SceneManager.LoadScene(levelName);
     }
 
-    public static Vector3 transformBackendPositionToFrontendPosition(OldPosition position)
+    public static Vector3 transformBackendOldPositionToFrontendPosition(OldPosition position)
     {
         var x = (long)position?.Y / 100f - 50.0f;
         var y = (-((long)position?.X)) / 100f + 50.0f;
+        return new Vector3(x, 1f, y);
+    }
+
+    public static Vector3 transformBackendPositionToFrontendPosition(Game.Position position)
+    {
+        var x = (long)position?.x / 100f;
+        var y = (long)position?.y / 100f;
         return new Vector3(x, 1f, y);
     }
 


### PR DESCRIPTION
Closes #[issue]

## Motivation

This is part of the work to make the client up to date with regards to backend representation

## Summary of changes

- Start using items game information from the new game state version
- Stop usage of old Loot protobuf class and use the internal representation Item class

## How has this been tested?

Locally, nothing should have changed with regards to UX

This PR depends on https://github.com/lambdaclass/game_backend/pull/123 for some minor fixes to be able to decode the new game state


## Checklist
- [x] I have tested the changes locally.
- [x] I self-reviewed the changes on GitHub, line by line.
- [ ] Tests have been added/updated.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] I have tested the changes in another devices.
  - [ ] Tested in iOS.
  - [ ] Tested in Android.
