### PR TITLE
Arrow buttons fixes

### DIFF
--- a/client/Assets/Prefabs/Camera/CharacterInfoCameraUI.prefab
+++ b/client/Assets/Prefabs/Camera/CharacterInfoCameraUI.prefab
@@ -622,7 +622,7 @@ MonoBehaviour:
   IdleAnimationParameterName: Idle
   DisabledAnimationParameterName: Disabled
   PressedAnimationParameterName: Pressed
-  MouseMode: 0
+  MouseMode: 1
   isBackButton: 0
   executeRelease: 0
 --- !u!1 &1345791317
@@ -1198,7 +1198,7 @@ MonoBehaviour:
   IdleAnimationParameterName: Idle
   DisabledAnimationParameterName: Disabled
   PressedAnimationParameterName: Pressed
-  MouseMode: 0
+  MouseMode: 1
   isBackButton: 0
   executeRelease: 0
 --- !u!1 &1892104622
@@ -2915,10 +2915,10 @@ RectTransform:
   m_Father: {fileID: 6022409185718782281}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 103.869995}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &1906279464892907978
 MonoBehaviour:

--- a/client/Assets/Prefabs/Characters/UICharacters/Muflus.prefab
+++ b/client/Assets/Prefabs/Characters/UICharacters/Muflus.prefab
@@ -109,7 +109,8 @@ PrefabInstance:
       propertyPath: m_Materials.Array.data[0]
       value: 
       objectReference: {fileID: 2100000, guid: b3695f510a8ed4832b290fc5ea073996, type: 2}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 5787343542375309291, guid: 15b66cc26325d4624aa55f5dbede2d7d, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: 15b66cc26325d4624aa55f5dbede2d7d, type: 3}
 --- !u!4 &2036211311006244463 stripped
 Transform:

--- a/client/Assets/Prefabs/Characters/UICharacters/Uma.prefab
+++ b/client/Assets/Prefabs/Characters/UICharacters/Uma.prefab
@@ -119,7 +119,8 @@ PrefabInstance:
       propertyPath: m_Name
       value: Uma Variant
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 365590702187463381, guid: 65c3fd135e9374442b95bdfb30610d87, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: 65c3fd135e9374442b95bdfb30610d87, type: 3}
 --- !u!4 &3076076844926093513 stripped
 Transform:

--- a/client/Assets/Scripts/CharactersManager.cs
+++ b/client/Assets/Scripts/CharactersManager.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using UnityEngine;
 using System.Linq;
+using UnityEngine;
 
 public class CharactersManager : MonoBehaviour
 {
@@ -27,7 +27,7 @@ public class CharactersManager : MonoBehaviour
     }
 
     // The available names should come from backend
-    private List<string> availableCharacterNames = new List<string>() { "Muflus" };
+    private List<string> availableCharacterNames = new List<string>() { "Muflus", "Uma" };
 
     public string GoToCharacter;
 

--- a/client/Assets/Scripts/UI/UIModelManager.cs
+++ b/client/Assets/Scripts/UI/UIModelManager.cs
@@ -1,8 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
-using UnityEngine;
 using System.Linq;
-using MoreMountains.TopDownEngine;
+using UnityEngine;
 
 public class UIModelManager : MonoBehaviour
 {
@@ -11,10 +10,13 @@ public class UIModelManager : MonoBehaviour
     bool animate = false;
     const float ANIMATION_INTERVAL = 20f;
     float animationClipDuration;
+    Coroutine characterAnimation;
 
     public void SetModel(string characterName)
     {
-        GameObject playerModel = CharactersManager.Instance.AvailableCharacters
+        GameObject playerModel = CharactersManager
+            .Instance
+            .AvailableCharacters
             .Single(character => character.name == characterName)
             .UIModel;
         GameObject modelClone = Instantiate(
@@ -25,13 +27,14 @@ public class UIModelManager : MonoBehaviour
         );
         animate = true;
         animationClipDuration = AnimationClipTime(modelClone.GetComponentInChildren<Animator>());
-        StartCoroutine(AnimateCharacter(modelClone));
+        characterAnimation = StartCoroutine(AnimateCharacter(modelClone));
     }
 
     public void RemoveCurrentModel()
     {
         if (playerModelContainer.transform.childCount > 0)
         {
+            StopCoroutine(characterAnimation);
             Destroy(playerModelContainer.transform.GetChild(0).gameObject);
         }
     }


### PR DESCRIPTION
Closes #1302 

## Motivation

In character info, if more than one player is available and you press the arrows and keep your finger there the action won't stop being trigger. This PR fixes that.

## Summary of changes

Add in CharactersManager.cs "Uma" in availableCharacterNames list and then go to characters info scene. If you press down and hold the arrows the action should not be trigger. If you click on them as fast as possible there shouldn't be error either

## Checklist
- [x] I have tested the changes locally.
- [ ] I self-reviewed the changes on GitHub, line by line.
- [ ] Tests have been added/updated.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] I have tested the changes in another devices.
  - [ ] Tested in iOS.
  - [ ] Tested in Android.
