### PR TITLE
Fix camera following player in multiplayer games

### DIFF
--- a/client/Assets/Scripts/CustomLevelManager.cs
+++ b/client/Assets/Scripts/CustomLevelManager.cs
@@ -288,11 +288,11 @@ public class CustomLevelManager : LevelManager
     {
         foreach (CustomCharacter player in this.PlayerPrefabs)
         {
-            // if (UInt64.Parse(player.PlayerID) == playerID)
-            // {
+            if (UInt64.Parse(player.PlayerID) == playerID)
+            {
             this.camera.SetTarget(player);
             this.camera.StartFollowing();
-            // }
+            }
         }
     }
 

--- a/client/Assets/Scripts/GameServerConnectionManager.cs
+++ b/client/Assets/Scripts/GameServerConnectionManager.cs
@@ -291,7 +291,7 @@ public class GameServerConnectionManager : MonoBehaviour
         }
         else
         {
-            return "wss://" + serverIp + path;
+            return "ws://" + serverIp + ":4000" + path;
         }
     }
 

--- a/client/Assets/Scripts/ServerConnection.cs
+++ b/client/Assets/Scripts/ServerConnection.cs
@@ -253,7 +253,7 @@ public class ServerConnection : MonoBehaviour
         }
         else
         {
-            return "wss://" + serverIp + path;
+            return "ws://" + serverIp + ":4000" + path;
         }
     }
 


### PR DESCRIPTION
## Motivation

Camera ins't being assigned to the players properly. There are cases where your camera is following a different player than the one you move.

## Summary of changes

Restore commented code to achieve the correct behavior.

## How has this been tested?

I played several games with 2+ players (phone, browser tabs, pc).

## Checklist
- [x] I have tested the changes locally.
- [x] I self-reviewed the changes on GitHub, line by line.
- [ ] Tests have been added/updated.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [x] I have tested the changes in another devices.
  - [ ] Tested in iOS.
  - [x] Tested in Android.
