### PR TITLE
Error prefab fix

### DIFF
--- a/client/Assets/Scenes/TitleScreen.unity
+++ b/client/Assets/Scenes/TitleScreen.unity
@@ -383,7 +383,7 @@ PrefabInstance:
     - target: {fileID: 5376578583088809359, guid: 74e8f34655b5949b69f18c0ed42a7d46,
         type: 3}
       propertyPath: m_IsActive
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5806504279995816320, guid: 74e8f34655b5949b69f18c0ed42a7d46,
         type: 3}
@@ -408,7 +408,7 @@ PrefabInstance:
     - target: {fileID: 8267120923094508676, guid: 74e8f34655b5949b69f18c0ed42a7d46,
         type: 3}
       propertyPath: m_IsActive
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 74e8f34655b5949b69f18c0ed42a7d46, type: 3}


### PR DESCRIPTION
In main the error container is deactivated therefore when there is an error connection the game thrown a null reference error