### PR TITLE
Re-enable lobby counter

### DIFF
--- a/client/Assets/Scenes/TitleScreen.unity
+++ b/client/Assets/Scenes/TitleScreen.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.3708708, g: 0.37838137, b: 0.35725543, a: 1}
+  m_IndirectSpecularColor: {r: 0.37311924, g: 0.38073963, b: 0.3587269, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -159,7 +159,7 @@ MonoBehaviour:
   playerId: 0
   playerCount: 0
   simulatedPlayerCount: 0
-  lobbyCapacity: 0
+  lobbyCapacity: 10
   serverTickRate_ms: 0
   serverHash: 
   gameStarted: 0

--- a/client/Assets/Scenes/TitleScreen.unity
+++ b/client/Assets/Scenes/TitleScreen.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.37311924, g: 0.38073963, b: 0.3587269, a: 1}
+  m_IndirectSpecularColor: {r: 0.3708708, g: 0.37838137, b: 0.35725543, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -159,7 +159,7 @@ MonoBehaviour:
   playerId: 0
   playerCount: 0
   simulatedPlayerCount: 0
-  lobbyCapacity: 10
+  lobbyCapacity: 0
   serverTickRate_ms: 0
   serverHash: 
   gameStarted: 0

--- a/client/Assets/Scripts/ServerConnection.cs
+++ b/client/Assets/Scripts/ServerConnection.cs
@@ -106,6 +106,7 @@ public class ServerConnection : MonoBehaviour
     {
         // ValidateVersionHashes();
         ConnectToSession();
+        InvokeRepeating("UpdateSimulatedCounter", 0, 1);
     }
 
     //     public void ConnectToLobby(string matchmaking_id)

--- a/client/Assets/Scripts/ServerConnection.cs
+++ b/client/Assets/Scripts/ServerConnection.cs
@@ -165,6 +165,7 @@ public class ServerConnection : MonoBehaviour
         try
         {
             GameState gameState = GameState.Parser.ParseFrom(data);
+            this.lobbyCapacity = 2;
             if (!String.IsNullOrEmpty(gameState.GameId) && SessionParameters.GameId == null)
             {
                 Debug.Log("no null " + gameState.GameId);


### PR DESCRIPTION
Closes #[issue]

## Motivation

We want to show live updates of the lobby getting filled

## Summary of changes

For now this only re-enables the fake counter we had

## How has this been tested?

Run the game

## Test additions / changes

List tests added/updated.

## Checklist
- [ ] I have tested the changes locally.
- [ ] I self-reviewed the changes on GitHub, line by line.
- [ ] Tests have been added/updated.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] I have tested the changes in another devices.
  - [ ] Tested in iOS.
  - [ ] Tested in Android.
