### PR TITLE
Add H4ck´s missing death prefab reference

### DIFF
--- a/client/Assets/Prefabs/Characters/H4ck.prefab
+++ b/client/Assets/Prefabs/Characters/H4ck.prefab
@@ -486,7 +486,7 @@ MonoBehaviour:
   - {fileID: 5395175593027007493}
   feedbacksPrefabs:
   - {fileID: 6057499254784400716}
-  deathFeedback: {fileID: 0}
+  deathFeedback: {fileID: 6777652408794094180}
   damageOverlayColor:
     serializedVersion: 2
     rgba: 4294967295
@@ -864,6 +864,12 @@ GameObject:
 --- !u!1 &6057499254784400716 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 8907776290301276495, guid: 9468612907e8942b49712f4e342b630c,
+    type: 3}
+  m_PrefabInstance: {fileID: 3426755726173006851}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &6777652408794094180 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8178896298581030503, guid: 9468612907e8942b49712f4e342b630c,
     type: 3}
   m_PrefabInstance: {fileID: 3426755726173006851}
   m_PrefabAsset: {fileID: 0}


### PR DESCRIPTION
## Motivation

H4ck `characterFeedbacks` script was missing the reference of the `deathFeedback` prefab breaking the game.

## Summary of changes

List changes in code.

## How has this been tested?

- Start a game with 2 h4cks with this branch https://github.com/lambdaclass/mirra_backend/pull/211 and change game_update.ex character name from muflus to h4ck.
- Kill 1 h4ck
- No errors should be deplayed in the unity console.

## Test additions / changes

List tests added/updated.

## Checklist
- [x] I have tested the changes locally.
- [x] I self-reviewed the changes on GitHub, line by line.
- [ ] Tests have been added/updated.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] I have tested the changes in another devices.
  - [ ] Tested in iOS.
  - [ ] Tested in Android.
