### PR TITLE
instantiate correct character

### DIFF
--- a/client/Assets/Scripts/CustomLevelManager.cs
+++ b/client/Assets/Scripts/CustomLevelManager.cs
@@ -138,7 +138,7 @@ public class CustomLevelManager : LevelManager
             GameObject prefab = CharactersManager
                 .Instance
                 .AvailableCharacters
-                .Find(el => el.name == CharactersManager.Instance.GoToCharacter)
+                .Find(el => el.name.ToLower() == player.Player.CharacterName)
                 .prefab;
 
             if (GameServerConnectionManager.Instance.playerId == player.Id)

--- a/client/Assets/Scripts/Messages.pb.cs
+++ b/client/Assets/Scripts/Messages.pb.cs
@@ -60,25 +60,25 @@ public static partial class MessagesReflection {
           "DQoFc3BlZWQYCSABKAISHQoJZGlyZWN0aW9uGAogASgLMgouRGlyZWN0aW9u",
           "EhEKCWlzX21vdmluZxgLIAEoCBIZCgZwbGF5ZXIYDCABKAsyBy5QbGF5ZXJI",
           "ABIhCgpwcm9qZWN0aWxlGA0gASgLMgsuUHJvamVjdGlsZUgAEh0KCG9ic3Rh",
-          "Y2xlGA4gASgLMgkuT2JzdGFjbGVIAEIQCg5hZGl0aW9uYWxfaW5mbyK6AQoG",
+          "Y2xlGA4gASgLMgkuT2JzdGFjbGVIAEIQCg5hZGl0aW9uYWxfaW5mbyLSAQoG",
           "UGxheWVyEg4KBmhlYWx0aBgBIAEoBBISCgpraWxsX2NvdW50GAIgASgEEiYK",
           "D2N1cnJlbnRfYWN0aW9ucxgDIAMoCzINLlBsYXllckFjdGlvbhIZChFhdmFp",
           "bGFibGVfc3RhbWluYRgEIAEoBBITCgttYXhfc3RhbWluYRgFIAEoBBIYChBz",
           "dGFtaW5hX2ludGVydmFsGAYgASgEEhoKEnJlY2hhcmdpbmdfc3RhbWluYRgH",
-          "IAEoCCJRCgpQcm9qZWN0aWxlEg4KBmRhbWFnZRgBIAEoBBIQCghvd25lcl9p",
-          "ZBgCIAEoBBIhCgZzdGF0dXMYAyABKA4yES5Qcm9qZWN0aWxlU3RhdHVzIhkK",
-          "CE9ic3RhY2xlEg0KBWNvbG9yGAEgASgJIkMKDFBsYXllckFjdGlvbhIhCgZh",
-          "Y3Rpb24YASABKA4yES5QbGF5ZXJBY3Rpb25UeXBlEhAKCGR1cmF0aW9uGAIg",
-          "ASgEIiUKBE1vdmUSHQoJZGlyZWN0aW9uGAEgASgLMgouRGlyZWN0aW9uIhcK",
-          "BkF0dGFjaxINCgVza2lsbBgBIAEoCSJgCgpHYW1lQWN0aW9uEhUKBG1vdmUY",
-          "ASABKAsyBS5Nb3ZlSAASGQoGYXR0YWNrGAIgASgLMgcuQXR0YWNrSAASEQoJ",
-          "dGltZXN0YW1wGAMgASgDQg0KC2FjdGlvbl90eXBlIhYKBFpvbmUSDgoGcmFk",
-          "aXVzGAEgASgCIjEKCUtpbGxFbnRyeRIRCglraWxsZXJfaWQYASABKAQSEQoJ",
-          "dmljdGltX2lkGAIgASgEKiwKEFByb2plY3RpbGVTdGF0dXMSCgoGQUNUSVZF",
-          "EAASDAoIRVhQTE9ERUQQASp4ChBQbGF5ZXJBY3Rpb25UeXBlEgoKBk1PVklO",
-          "RxAAEhQKEFNUQVJUSU5HX1NLSUxMXzEQARIUChBTVEFSVElOR19TS0lMTF8y",
-          "EAISFQoRRVhFQ1VUSU5HX1NLSUxMXzEQAxIVChFFWEVDVVRJTkdfU0tJTExf",
-          "MhAEYgZwcm90bzM="));
+          "IAEoCBIWCg5jaGFyYWN0ZXJfbmFtZRgIIAEoCSJRCgpQcm9qZWN0aWxlEg4K",
+          "BmRhbWFnZRgBIAEoBBIQCghvd25lcl9pZBgCIAEoBBIhCgZzdGF0dXMYAyAB",
+          "KA4yES5Qcm9qZWN0aWxlU3RhdHVzIhkKCE9ic3RhY2xlEg0KBWNvbG9yGAEg",
+          "ASgJIkMKDFBsYXllckFjdGlvbhIhCgZhY3Rpb24YASABKA4yES5QbGF5ZXJB",
+          "Y3Rpb25UeXBlEhAKCGR1cmF0aW9uGAIgASgEIiUKBE1vdmUSHQoJZGlyZWN0",
+          "aW9uGAEgASgLMgouRGlyZWN0aW9uIhcKBkF0dGFjaxINCgVza2lsbBgBIAEo",
+          "CSJgCgpHYW1lQWN0aW9uEhUKBG1vdmUYASABKAsyBS5Nb3ZlSAASGQoGYXR0",
+          "YWNrGAIgASgLMgcuQXR0YWNrSAASEQoJdGltZXN0YW1wGAMgASgDQg0KC2Fj",
+          "dGlvbl90eXBlIhYKBFpvbmUSDgoGcmFkaXVzGAEgASgCIjEKCUtpbGxFbnRy",
+          "eRIRCglraWxsZXJfaWQYASABKAQSEQoJdmljdGltX2lkGAIgASgEKiwKEFBy",
+          "b2plY3RpbGVTdGF0dXMSCgoGQUNUSVZFEAASDAoIRVhQTE9ERUQQASp4ChBQ",
+          "bGF5ZXJBY3Rpb25UeXBlEgoKBk1PVklORxAAEhQKEFNUQVJUSU5HX1NLSUxM",
+          "XzEQARIUChBTVEFSVElOR19TS0lMTF8yEAISFQoRRVhFQ1VUSU5HX1NLSUxM",
+          "XzEQAxIVChFFWEVDVVRJTkdfU0tJTExfMhAEYgZwcm90bzM="));
     descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
         new pbr::FileDescriptor[] { },
         new pbr::GeneratedClrTypeInfo(new[] {typeof(global::ProjectileStatus), typeof(global::PlayerActionType), }, null, new pbr::GeneratedClrTypeInfo[] {
@@ -95,7 +95,7 @@ public static partial class MessagesReflection {
           new pbr::GeneratedClrTypeInfo(typeof(global::ConfigSkill), global::ConfigSkill.Parser, new[]{ "Name", "CooldownMs", "ExecutionDurationMs" }, null, null, null, null),
           new pbr::GeneratedClrTypeInfo(typeof(global::GameState), global::GameState.Parser, new[]{ "GameId", "Players", "Projectiles", "PlayerTimestamps", "ServerTimestamp", "Zone", "Killfeed" }, null, null, null, new pbr::GeneratedClrTypeInfo[] { null, null, null, }),
           new pbr::GeneratedClrTypeInfo(typeof(global::Entity), global::Entity.Parser, new[]{ "Id", "Category", "Shape", "Name", "Position", "Radius", "Vertices", "CollidesWith", "Speed", "Direction", "IsMoving", "Player", "Projectile", "Obstacle" }, new[]{ "AditionalInfo" }, null, null, null),
-          new pbr::GeneratedClrTypeInfo(typeof(global::Player), global::Player.Parser, new[]{ "Health", "KillCount", "CurrentActions", "AvailableStamina", "MaxStamina", "StaminaInterval", "RechargingStamina" }, null, null, null, null),
+          new pbr::GeneratedClrTypeInfo(typeof(global::Player), global::Player.Parser, new[]{ "Health", "KillCount", "CurrentActions", "AvailableStamina", "MaxStamina", "StaminaInterval", "RechargingStamina", "CharacterName" }, null, null, null, null),
           new pbr::GeneratedClrTypeInfo(typeof(global::Projectile), global::Projectile.Parser, new[]{ "Damage", "OwnerId", "Status" }, null, null, null, null),
           new pbr::GeneratedClrTypeInfo(typeof(global::Obstacle), global::Obstacle.Parser, new[]{ "Color" }, null, null, null, null),
           new pbr::GeneratedClrTypeInfo(typeof(global::PlayerAction), global::PlayerAction.Parser, new[]{ "Action", "Duration" }, null, null, null, null),
@@ -4115,6 +4115,7 @@ public sealed partial class Player : pb::IMessage<Player>
     maxStamina_ = other.maxStamina_;
     staminaInterval_ = other.staminaInterval_;
     rechargingStamina_ = other.rechargingStamina_;
+    characterName_ = other.characterName_;
     _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
   }
 
@@ -4207,6 +4208,18 @@ public sealed partial class Player : pb::IMessage<Player>
     }
   }
 
+  /// <summary>Field number for the "character_name" field.</summary>
+  public const int CharacterNameFieldNumber = 8;
+  private string characterName_ = "";
+  [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+  [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+  public string CharacterName {
+    get { return characterName_; }
+    set {
+      characterName_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+    }
+  }
+
   [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
   [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
   public override bool Equals(object other) {
@@ -4229,6 +4242,7 @@ public sealed partial class Player : pb::IMessage<Player>
     if (MaxStamina != other.MaxStamina) return false;
     if (StaminaInterval != other.StaminaInterval) return false;
     if (RechargingStamina != other.RechargingStamina) return false;
+    if (CharacterName != other.CharacterName) return false;
     return Equals(_unknownFields, other._unknownFields);
   }
 
@@ -4243,6 +4257,7 @@ public sealed partial class Player : pb::IMessage<Player>
     if (MaxStamina != 0UL) hash ^= MaxStamina.GetHashCode();
     if (StaminaInterval != 0UL) hash ^= StaminaInterval.GetHashCode();
     if (RechargingStamina != false) hash ^= RechargingStamina.GetHashCode();
+    if (CharacterName.Length != 0) hash ^= CharacterName.GetHashCode();
     if (_unknownFields != null) {
       hash ^= _unknownFields.GetHashCode();
     }
@@ -4286,6 +4301,10 @@ public sealed partial class Player : pb::IMessage<Player>
       output.WriteRawTag(56);
       output.WriteBool(RechargingStamina);
     }
+    if (CharacterName.Length != 0) {
+      output.WriteRawTag(66);
+      output.WriteString(CharacterName);
+    }
     if (_unknownFields != null) {
       _unknownFields.WriteTo(output);
     }
@@ -4321,6 +4340,10 @@ public sealed partial class Player : pb::IMessage<Player>
       output.WriteRawTag(56);
       output.WriteBool(RechargingStamina);
     }
+    if (CharacterName.Length != 0) {
+      output.WriteRawTag(66);
+      output.WriteString(CharacterName);
+    }
     if (_unknownFields != null) {
       _unknownFields.WriteTo(ref output);
     }
@@ -4349,6 +4372,9 @@ public sealed partial class Player : pb::IMessage<Player>
     }
     if (RechargingStamina != false) {
       size += 1 + 1;
+    }
+    if (CharacterName.Length != 0) {
+      size += 1 + pb::CodedOutputStream.ComputeStringSize(CharacterName);
     }
     if (_unknownFields != null) {
       size += _unknownFields.CalculateSize();
@@ -4380,6 +4406,9 @@ public sealed partial class Player : pb::IMessage<Player>
     }
     if (other.RechargingStamina != false) {
       RechargingStamina = other.RechargingStamina;
+    }
+    if (other.CharacterName.Length != 0) {
+      CharacterName = other.CharacterName;
     }
     _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
   }
@@ -4424,6 +4453,10 @@ public sealed partial class Player : pb::IMessage<Player>
           RechargingStamina = input.ReadBool();
           break;
         }
+        case 66: {
+          CharacterName = input.ReadString();
+          break;
+        }
       }
     }
   #endif
@@ -4465,6 +4498,10 @@ public sealed partial class Player : pb::IMessage<Player>
         }
         case 56: {
           RechargingStamina = input.ReadBool();
+          break;
+        }
+        case 66: {
+          CharacterName = input.ReadString();
           break;
         }
       }

--- a/client/Assets/Scripts/UI/EndGame/EndGameManager.cs
+++ b/client/Assets/Scripts/UI/EndGame/EndGameManager.cs
@@ -17,12 +17,6 @@ public class EndGameManager : MonoBehaviour
     GameObject defeatedByContainer,
         characterModelContainer;
 
-    // Data to be added from front and back
-
-    [SerializeField]
-    TextMeshProUGUI defeaterPlayerName,
-        defeaterCharacterName;
-
     [SerializeField]
     Image defeaterImage;
 
@@ -106,8 +100,6 @@ public class EndGameManager : MonoBehaviour
             //defeaterPlayerName.text = GetDefeaterPlayerName();
             // Defeated By Image
             defeaterImage.sprite = GetDefeaterSprite();
-            // Defeated By Name
-            // defeaterCharacterName.text = GetDefeaterCharacterName();
         }
     }
 
@@ -117,12 +109,6 @@ public class EndGameManager : MonoBehaviour
         // var gamePlayer = Utils.GetGamePlayer(playerId);
         // return gamePlayer.KillCount;
         return 77;
-    }
-
-    private string GetDefeaterPlayerName()
-    {
-        // TODO: get Defeater player name
-        return "-";
     }
 
     private Sprite GetDefeaterSprite()
@@ -150,17 +136,6 @@ public class EndGameManager : MonoBehaviour
                 );
             return killerCharacter.UIIcon;
         }
-    }
-
-    private string GetDefeaterCharacterName()
-    {
-        string characterName = Utils
-            .GetGamePlayer(KillFeedManager.instance.myKillerId)
-            .Player
-            .CharacterName;
-        characterName[0].ToString().ToUpper();
-
-        return characterName;
     }
 
     public void ShowCharacterAnimation()

--- a/client/Assets/Scripts/UI/EndGame/EndGameManager.cs
+++ b/client/Assets/Scripts/UI/EndGame/EndGameManager.cs
@@ -107,7 +107,7 @@ public class EndGameManager : MonoBehaviour
             // Defeated By Image
             defeaterImage.sprite = GetDefeaterSprite();
             // Defeated By Name
-            //defeaterCharacterName.text = GetDefeaterCharacterName();
+            // defeaterCharacterName.text = GetDefeaterCharacterName();
         }
     }
 
@@ -154,8 +154,13 @@ public class EndGameManager : MonoBehaviour
 
     private string GetDefeaterCharacterName()
     {
-        // TODO: get defeater character name
-        return "-";
+        string characterName = Utils
+            .GetGamePlayer(KillFeedManager.instance.myKillerId)
+            .Player
+            .CharacterName;
+        characterName[0].ToString().ToUpper();
+
+        return characterName;
     }
 
     public void ShowCharacterAnimation()

--- a/messages.proto
+++ b/messages.proto
@@ -128,6 +128,7 @@ message Player {
   uint64 max_stamina = 5;
   uint64 stamina_interval = 6;
   bool recharging_stamina = 7;
+  string character_name = 8;
 }
 
 message Projectile {


### PR DESCRIPTION
## Motivation

Instantiate the correct character for each player.

## How has this been tested?

Start a game with 2 players. With one select muflus and the other h4ck. When the game start you should see 1 muflus and 1 hack.

Test with https://github.com/lambdaclass/mirra_backend/pull/233

## Test additions / changes

List tests added/updated.

## Checklist
- [ ] I have tested the changes locally.
- [ ] I self-reviewed the changes on GitHub, line by line.
- [ ] Tests have been added/updated.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] I have tested the changes in another devices.
  - [ ] Tested in iOS.
  - [ ] Tested in Android.
