### PR TITLE
Fix health bar not reducing on damage

### DIFF
--- a/client/Assets/Scripts/CustomLevelManager.cs
+++ b/client/Assets/Scripts/CustomLevelManager.cs
@@ -155,6 +155,8 @@ public class CustomLevelManager : LevelManager
                 new Vector3(0.0f, 1.0f, 0.0f),
                 Quaternion.identity
             );
+            newPlayer.CharacterHealth.InitialHealth = player.Player.Health;
+            newPlayer.CharacterHealth.MaximumHealth = player.Player.Health;
             newPlayer.name = "Player" + player.Id;
             newPlayer.PlayerID = player.Id.ToString();
             // if (GameServerConnectionManager.Instance.playerId == playerID)


### PR DESCRIPTION
Closes #1403

## Motivation

When the health of the player surplus 100 the client health bar is not displaying the damage. (but it is happening)

## Summary of changes

Set Initial health and max health on player creation.

## How has this been tested?

Describe the steps you performed to test this PR.

## Test additions / changes

List tests added/updated.

## Checklist
- [x] I have tested the changes locally.
- [x] I self-reviewed the changes on GitHub, line by line.
- [ ] Tests have been added/updated.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] I have tested the changes in another devices.
  - [ ] Tested in iOS.
  - [ ] Tested in Android.
