### PR TITLE
Improve Damage Feedback

### DIFF
--- a/client/Assets/Prefabs/Camera/CameraUI.prefab
+++ b/client/Assets/Prefabs/Camera/CameraUI.prefab
@@ -526,6 +526,7 @@ RectTransform:
   m_LocalScale: {x: 0, y: 0, z: 0}
   m_ConstrainProportionsScale: 0
   m_Children:
+  - {fileID: 1558749284821676708}
   - {fileID: 1531348733418472702}
   - {fileID: 1776069428583422584}
   - {fileID: 6579593011659604296}
@@ -5817,7 +5818,7 @@ RectTransform:
   - {fileID: 7244019777335054706}
   - {fileID: 4694456534383602725}
   m_Father: {fileID: 224931852115754924}
-  m_RootOrder: 2
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -7598,7 +7599,7 @@ RectTransform:
   - {fileID: 1413022483004132574}
   - {fileID: 2515833497268833504}
   m_Father: {fileID: 224931852115754924}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -9076,7 +9077,7 @@ RectTransform:
   m_Children:
   - {fileID: 5384320640838588139}
   m_Father: {fileID: 224931852115754924}
-  m_RootOrder: 0
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -19747,6 +19748,148 @@ MonoBehaviour:
   m_ChildScaleWidth: 0
   m_ChildScaleHeight: 0
   m_ReverseArrangement: 0
+--- !u!1 &4176706644108430116
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1558749284821676708}
+  - component: {fileID: 1864119703089635465}
+  - component: {fileID: 6372890940750595876}
+  - component: {fileID: 5186851492907169581}
+  - component: {fileID: 8195127304710708841}
+  m_Layer: 5
+  m_Name: Fader
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1558749284821676708
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4176706644108430116}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 224931852115754924}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!225 &1864119703089635465
+CanvasGroup:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4176706644108430116}
+  m_Enabled: 1
+  m_Alpha: 0
+  m_Interactable: 1
+  m_BlocksRaycasts: 1
+  m_IgnoreParentGroups: 0
+--- !u!222 &6372890940750595876
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4176706644108430116}
+  m_CullTransparentMesh: 1
+--- !u!114 &5186851492907169581
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4176706644108430116}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 0, b: 0, a: 0.34901962}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &8195127304710708841
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4176706644108430116}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: efe052b91c95c534b8bf0f64fb0b9151, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ID: 0
+  InactiveAlpha: 0
+  ActiveAlpha: 1
+  ForcedInitState: 2
+  DefaultDuration: 0.2
+  DefaultTween:
+    MMTweenDefinitionType: 0
+    MMTweenCurve: 0
+    Curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      - serializedVersion: 3
+        time: 1
+        value: 1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: 0
+        outWeight: 0
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    Initialized: 0
+  IgnoreTimescale: 1
+  CanFadeToCurrentAlpha: 1
+  ShouldBlockRaycasts: 0
+  FadeIn1SecondButton: 0
+  FadeOut1SecondButton: 0
+  DefaultFadeButton: 0
+  ResetFaderButton: 0
 --- !u!1 &4190701241990048127
 GameObject:
   m_ObjectHideFlags: 0

--- a/client/Assets/Prefabs/Characters/H4ck.prefab
+++ b/client/Assets/Prefabs/Characters/H4ck.prefab
@@ -488,6 +488,7 @@ MonoBehaviour:
   - {fileID: 6057499254784400716}
   - {fileID: 2341843589675793722}
   deathFeedback: {fileID: 6777652408794094180}
+  healthBar: {fileID: 2635068537373217531}
   damageOverlayColor:
     serializedVersion: 2
     rgba: 4294967295

--- a/client/Assets/Prefabs/Characters/Muflus.prefab
+++ b/client/Assets/Prefabs/Characters/Muflus.prefab
@@ -489,6 +489,7 @@ MonoBehaviour:
   - {fileID: 604736327119138052}
   - {fileID: 8938270116862053746}
   deathFeedback: {fileID: 179007033852684844}
+  healthBar: {fileID: 8711474442059621043}
   damageOverlayColor:
     serializedVersion: 2
     rgba: 4294967295

--- a/client/Assets/Prefabs/Characters/Uma.prefab
+++ b/client/Assets/Prefabs/Characters/Uma.prefab
@@ -488,6 +488,7 @@ MonoBehaviour:
   - {fileID: 4875194947177718696}
   - {fileID: 4019254676187120606}
   deathFeedback: {fileID: 5311901717291246720}
+  healthBar: {fileID: 3686478168088177695}
   damageOverlayColor:
     serializedVersion: 2
     rgba: 4294967295
@@ -791,15 +792,3 @@ Animator:
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorStateOnDisable: 0
   m_WriteDefaultValuesOnDisable: 0
---- !u!114 &5650130236907762616
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7659923000860470122}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c8db6bc3b8dc9489d8a93cbf462694b9, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 

--- a/client/Assets/Prefabs/Feedbacks/DamageFeedback.prefab
+++ b/client/Assets/Prefabs/Feedbacks/DamageFeedback.prefab
@@ -122,17 +122,19 @@ MonoBehaviour:
   FeedbacksList:
   - rid: 8225093901390184455
   - rid: 8991264300308103170
+  - rid: 9057537247632424962
+  - rid: 9057537247632424963
   KeepPlayModeChanges: 0
   PerformanceMode: 0
   ForceStopFeedbacksOnDisable: 1
-  PlayCount: 54
+  PlayCount: 115
   references:
     version: 2
     RefIds:
     - rid: 8225093901390184455
       type: {class: MMF_Flash, ns: MoreMountains.Feedbacks, asm: MoreMountains.Feedbacks}
       data:
-        Active: 1
+        Active: 0
         UniqueID: -1515569768
         Label: Flash
         ChannelMode: 0
@@ -313,3 +315,213 @@ MonoBehaviour:
           m_PropagationSpeed: 343
         Velocity: {x: 0.3, y: 0.5, z: 0.3}
         ClearImpulseOnStop: 0
+    - rid: 9057537247632424962
+      type: {class: MMF_Fade, ns: MoreMountains.Feedbacks, asm: MoreMountains.Feedbacks.MMTools}
+      data:
+        Active: 1
+        UniqueID: 2080423892
+        Label: Fade
+        ChannelMode: 0
+        Channel: 0
+        MMChannelDefinition: {fileID: 0}
+        Chance: 100
+        DisplayColor: {r: 0, g: 0, b: 0, a: 1}
+        Timing:
+          TimescaleMode: 0
+          ExcludeFromHoldingPauses: 0
+          ContributeToTotalDuration: 1
+          InitialDelay: 0
+          CooldownDuration: 0
+          InterruptsOnStop: 1
+          NumberOfRepeats: 0
+          RepeatForever: 0
+          DelayBetweenRepeats: 1
+          MMFeedbacksDirectionCondition: 0
+          PlayDirection: 0
+          ConstantIntensity: 0
+          UseIntensityInterval: 0
+          IntensityIntervalMin: 0
+          IntensityIntervalMax: 0
+          Sequence: {fileID: 0}
+          TrackID: 0
+          Quantized: 0
+          TargetBPM: 120
+        AutomatedTargetAcquisition:
+          Mode: 0
+          ChildIndex: 0
+        RandomizeOutput: 0
+        RandomMultiplier: {x: 0.8, y: 1}
+        RandomizeDuration: 0
+        RandomDurationMultiplier: {x: 0.5, y: 2}
+        UseRange: 0
+        RangeDistance: 5
+        UseRangeFalloff: 0
+        RangeFalloff:
+          serializedVersion: 2
+          m_Curve:
+          - serializedVersion: 3
+            time: 0
+            value: 1
+            inSlope: 0
+            outSlope: 0
+            tangentMode: 0
+            weightedMode: 0
+            inWeight: 0
+            outWeight: 0
+          - serializedVersion: 3
+            time: 1
+            value: 0
+            inSlope: 0
+            outSlope: 0
+            tangentMode: 0
+            weightedMode: 0
+            inWeight: 0
+            outWeight: 0
+          m_PreInfinity: 2
+          m_PostInfinity: 2
+          m_RotationOrder: 4
+        RemapRangeFalloff: {x: 0, y: 1}
+        Owner: {fileID: 1438067562074111280}
+        DebugActive: 0
+        FadeType: 0
+        ID: 0
+        Duration: 0.3
+        Curve:
+          MMTweenDefinitionType: 1
+          MMTweenCurve: 4
+          Curve:
+            serializedVersion: 2
+            m_Curve:
+            - serializedVersion: 3
+              time: 0
+              value: 0
+              inSlope: 7.075668
+              outSlope: 7.075668
+              tangentMode: 34
+              weightedMode: 0
+              inWeight: 0
+              outWeight: 0.33333334
+            - serializedVersion: 3
+              time: 0.1416626
+              value: 1.0023575
+              inSlope: 7.075668
+              outSlope: 7.075668
+              tangentMode: 34
+              weightedMode: 0
+              inWeight: 0.33333334
+              outWeight: 0
+            m_PreInfinity: 2
+            m_PostInfinity: 2
+            m_RotationOrder: 4
+          Initialized: 0
+        IgnoreTimeScale: 1
+        TargetAlpha: 0
+        PositionMode: 0
+        TargetTransform: {fileID: 0}
+        TargetPosition: {x: 0, y: 0, z: 0}
+        PositionOffset: {x: 0, y: 0, z: 0}
+    - rid: 9057537247632424963
+      type: {class: MMF_Fade, ns: MoreMountains.Feedbacks, asm: MoreMountains.Feedbacks.MMTools}
+      data:
+        Active: 1
+        UniqueID: 958915349
+        Label: Fade
+        ChannelMode: 0
+        Channel: 0
+        MMChannelDefinition: {fileID: 0}
+        Chance: 100
+        DisplayColor: {r: 0, g: 0, b: 0, a: 1}
+        Timing:
+          TimescaleMode: 0
+          ExcludeFromHoldingPauses: 0
+          ContributeToTotalDuration: 1
+          InitialDelay: 0
+          CooldownDuration: 0
+          InterruptsOnStop: 1
+          NumberOfRepeats: 0
+          RepeatForever: 0
+          DelayBetweenRepeats: 1
+          MMFeedbacksDirectionCondition: 0
+          PlayDirection: 0
+          ConstantIntensity: 0
+          UseIntensityInterval: 0
+          IntensityIntervalMin: 0
+          IntensityIntervalMax: 0
+          Sequence: {fileID: 0}
+          TrackID: 0
+          Quantized: 0
+          TargetBPM: 120
+        AutomatedTargetAcquisition:
+          Mode: 0
+          ChildIndex: 0
+        RandomizeOutput: 0
+        RandomMultiplier: {x: 0.8, y: 1}
+        RandomizeDuration: 0
+        RandomDurationMultiplier: {x: 0.5, y: 2}
+        UseRange: 0
+        RangeDistance: 5
+        UseRangeFalloff: 0
+        RangeFalloff:
+          serializedVersion: 2
+          m_Curve:
+          - serializedVersion: 3
+            time: 0
+            value: 1
+            inSlope: 0
+            outSlope: 0
+            tangentMode: 0
+            weightedMode: 0
+            inWeight: 0
+            outWeight: 0
+          - serializedVersion: 3
+            time: 1
+            value: 0
+            inSlope: 0
+            outSlope: 0
+            tangentMode: 0
+            weightedMode: 0
+            inWeight: 0
+            outWeight: 0
+          m_PreInfinity: 2
+          m_PostInfinity: 2
+          m_RotationOrder: 4
+        RemapRangeFalloff: {x: 0, y: 1}
+        Owner: {fileID: 1438067562074111280}
+        DebugActive: 0
+        FadeType: 1
+        ID: 0
+        Duration: 1
+        Curve:
+          MMTweenDefinitionType: 1
+          MMTweenCurve: 4
+          Curve:
+            serializedVersion: 2
+            m_Curve:
+            - serializedVersion: 3
+              time: 0
+              value: 0
+              inSlope: 2
+              outSlope: 2
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0
+              outWeight: 0
+            - serializedVersion: 3
+              time: 1
+              value: 1
+              inSlope: 0
+              outSlope: 0
+              tangentMode: 0
+              weightedMode: 0
+              inWeight: 0
+              outWeight: 0
+            m_PreInfinity: 2
+            m_PostInfinity: 2
+            m_RotationOrder: 4
+          Initialized: 0
+        IgnoreTimeScale: 1
+        TargetAlpha: 0
+        PositionMode: 0
+        TargetTransform: {fileID: 0}
+        TargetPosition: {x: 0, y: 0, z: 0}
+        PositionOffset: {x: 0, y: 0, z: 0}

--- a/client/Assets/Prefabs/Feedbacks/DamageFeedback.prefab
+++ b/client/Assets/Prefabs/Feedbacks/DamageFeedback.prefab
@@ -490,7 +490,7 @@ MonoBehaviour:
         DebugActive: 0
         FadeType: 1
         ID: 0
-        Duration: 1
+        Duration: 0.7
         Curve:
           MMTweenDefinitionType: 1
           MMTweenCurve: 4

--- a/client/Assets/Prefabs/HealthBar.prefab
+++ b/client/Assets/Prefabs/HealthBar.prefab
@@ -252,7 +252,7 @@ MonoBehaviour:
   BumpScaleOnChange: 1
   BumpOnIncrease: 0
   BumpOnDecrease: 0
-  BumpDuration: 0.2
+  BumpDuration: 0.8
   ChangeColorWhenBumping: 1
   StoreBarColorOnPlay: 1
   BumpColor: {r: 1, g: 1, b: 1, a: 1}
@@ -260,23 +260,14 @@ MonoBehaviour:
     serializedVersion: 2
     m_Curve:
     - serializedVersion: 3
-      time: 0.3
-      value: 1.05
-      inSlope: 0
-      outSlope: 0
+      time: 0.0859406
+      value: 1.485065
+      inSlope: -0.5750396
+      outSlope: -0.5750396
       tangentMode: 0
       weightedMode: 0
       inWeight: 0
-      outWeight: 0
-    - serializedVersion: 3
-      time: 1
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0
-      outWeight: 0
+      outWeight: 0.38022822
     - serializedVersion: 3
       time: 1
       value: 1
@@ -351,10 +342,10 @@ MonoBehaviour:
   TestBumpButton: 0
   Plus10PercentButton: 0
   Minus10PercentButton: 0
-  BarProgress: 0
-  BarTarget: 0
-  DelayedBarIncreasingProgress: 0
-  DelayedBarDecreasingProgress: 0
+  BarProgress: 0.52
+  BarTarget: 0.52
+  DelayedBarIncreasingProgress: 0.52
+  DelayedBarDecreasingProgress: 0.53
 --- !u!1 &1000011386624708
 GameObject:
   m_ObjectHideFlags: 0

--- a/client/Assets/Prefabs/HealthBar.prefab
+++ b/client/Assets/Prefabs/HealthBar.prefab
@@ -251,7 +251,7 @@ MonoBehaviour:
     m_RotationOrder: 4
   BumpScaleOnChange: 0
   BumpOnIncrease: 0
-  BumpOnDecrease: 1
+  BumpOnDecrease: 0
   BumpDuration: 0.8
   ChangeColorWhenBumping: 1
   StoreBarColorOnPlay: 1

--- a/client/Assets/Prefabs/HealthBar.prefab
+++ b/client/Assets/Prefabs/HealthBar.prefab
@@ -249,9 +249,9 @@ MonoBehaviour:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
-  BumpScaleOnChange: 1
+  BumpScaleOnChange: 0
   BumpOnIncrease: 0
-  BumpOnDecrease: 0
+  BumpOnDecrease: 1
   BumpDuration: 0.8
   ChangeColorWhenBumping: 1
   StoreBarColorOnPlay: 1

--- a/client/Assets/Scripts/CharacterFeedbacks.cs
+++ b/client/Assets/Scripts/CharacterFeedbacks.cs
@@ -2,6 +2,7 @@ using System.Collections;
 using System.Collections.Generic;
 using CandyCoded.HapticFeedback;
 using MoreMountains.Feedbacks;
+using MoreMountains.Tools;
 using UnityEngine;
 
 public class CharacterFeedbacks : MonoBehaviour
@@ -19,6 +20,8 @@ public class CharacterFeedbacks : MonoBehaviour
 
     [SerializeField]
     GameObject deathFeedback;
+
+    [SerializeField] MMProgressBar healthBar;
 
     [SerializeField]
     Color32 damageOverlayColor = new Color32(255, 255, 255, 255);
@@ -91,6 +94,7 @@ public class CharacterFeedbacks : MonoBehaviour
             this.GetFeedback("DamageFeedback").GetComponent<MMF_Player>().PlayFeedbacks();
             this.HapticFeedbackOnDamage();
             this.ChangePlayerTextureOnDamage(clientHealth, playerHealth);
+            this.healthBar.BumpOnDecrease = true;
         }
     }
 


### PR DESCRIPTION
Closes #1344 

## Motivation

Improve damage feedback from a instant fash to a fade.  The main difference here is when the red screen disappear. Now it is not instantly and is more smooth.

https://github.com/lambdaclass/curse_of_mirra/assets/62818001/e4eb87f3-f24d-4cf2-88ca-efa8f533e1c0

**Ignore the pink squares. I do not have loaded the assets.**

## Summary of changes

Change DamageFeedback prefab and add fader object to CameraUI

## How has this been tested?
Test with this backend branch : https://github.com/lambdaclass/mirra_backend/pull/244
Start a game and receive damage.

Disclaimer: The damage when you receive it from the danger zone could be too much. This is because we are dealing the damage from the backend in every tick. We either left this until the backend is fixed or make a temporary workaround in the client.

## Test additions / changes

List tests added/updated.

## Checklist
- [x] I have tested the changes locally.
- [x] I self-reviewed the changes on GitHub, line by line.
- [ ] Tests have been added/updated.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] I have tested the changes in another devices.
  - [ ] Tested in iOS.
  - [ ] Tested in Android.
