### PR TITLE
Swap input 2 and 3 positions

### DIFF
--- a/client/Assets/Prefabs/Camera/CameraUI.prefab
+++ b/client/Assets/Prefabs/Camera/CameraUI.prefab
@@ -9533,7 +9533,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 514.9, y: -105.3}
+  m_AnchoredPosition: {x: 690.4, y: -47.6}
   m_SizeDelta: {x: 350, y: 350}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &2879569505611247586
@@ -38848,7 +38848,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 690.4, y: -47.6}
+  m_AnchoredPosition: {x: 514.9, y: -105.3}
   m_SizeDelta: {x: 350, y: 350}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &4033361733791390897


### PR DESCRIPTION
## Motivation

The team thinks it's better to have the dash skill input on the top

## Summary of changes

This PR swaps skill 2 and skill 3 (dash)'s positions

## Checklist
- [ ] I have tested the changes locally.
- [ ] I self-reviewed the changes on GitHub, line by line.
- [ ] Tests have been added/updated.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] I have tested the changes in another devices.
  - [ ] Tested in iOS.
  - [ ] Tested in Android.
