### PR TITLE
Fix showing wrong vfx

### DIFF
--- a/client/Assets/Scripts/CustomLevelManager.cs
+++ b/client/Assets/Scripts/CustomLevelManager.cs
@@ -263,7 +263,7 @@ public class CustomLevelManager : LevelManager
             CoMCharacter characterInfo = CharactersManager
                 .Instance
                 .AvailableCharacters
-                .Find(el => el.name == CharactersManager.Instance.GoToCharacter);
+                .Find(el => el.name.ToLower() == player.CharacterModel.name.ToLower());
 
             List<SkillInfo> skillInfoClone = InitSkills(characterInfo);
             // SetSkillAngles(skillInfoClone);


### PR DESCRIPTION
## Motivation

The vfx was showing wrong. Only the vfx of what character you selected was being displayed.  With this each character skills are set correctly.

## Summary of changes

## How has this been tested?

Play a game with 2 or more players. You should see each character vfx correctly

## Test additions / changes

List tests added/updated.

## Checklist
- [x] I have tested the changes locally.
- [x] I self-reviewed the changes on GitHub, line by line.
- [ ] Tests have been added/updated.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] I have tested the changes in another devices.
  - [ ] Tested in iOS.
  - [ ] Tested in Android.
