### PR TITLE
Players spawn position fix

### DIFF
--- a/client/Assets/Scripts/CustomLevelManager.cs
+++ b/client/Assets/Scripts/CustomLevelManager.cs
@@ -150,14 +150,21 @@ public class CustomLevelManager : LevelManager
             {
                 prefab.GetComponent<CustomCharacter>().PlayerID = "";
             }
+            Vector3 backToFrontPosition = Utils.transformBackendOldPositionToFrontendPosition(
+                player.Position
+            );
             CustomCharacter newPlayer = Instantiate(
                 prefab.GetComponent<CustomCharacter>(),
-                new Vector3(0.0f, 1.0f, 0.0f),
+                new Vector3(backToFrontPosition.x, 1.0f, backToFrontPosition.z),
                 Quaternion.identity
             );
 
-            if(GameServerConnectionManager.Instance.playerId == player.Id){
-                Instantiate(newPlayer.characterBase.StaminaCharges,newPlayer.characterBase.CanvasHolder.transform);
+            if (GameServerConnectionManager.Instance.playerId == player.Id)
+            {
+                Instantiate(
+                    newPlayer.characterBase.StaminaCharges,
+                    newPlayer.characterBase.CanvasHolder.transform
+                );
             }
             newPlayer.CharacterHealth.InitialHealth = player.Player.Health;
             newPlayer.CharacterHealth.MaximumHealth = player.Player.Health;


### PR DESCRIPTION
Player should spawn in their initial position (and not "walk" to it when the map is loaded).

## Checklist
- [x] I have tested the changes locally.
- [x] I self-reviewed the changes on GitHub, line by line.
- [ ] Tests have been added/updated.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] I have tested the changes in another devices.
  - [ ] Tested in iOS.
  - [ ] Tested in Android.
