### PR TITLE
Desactivate stamina on death

### DIFF
--- a/client/Assets/Scripts/CustomCharacter.cs
+++ b/client/Assets/Scripts/CustomCharacter.cs
@@ -39,8 +39,6 @@ public class CustomCharacter : Character
         this.characterBase.Hitbox.SetActive(false);
         DestroySkillsClone();
         this.characterBase.CanvasHolder.SetActive(false);
-        // this.characterBase.OrientationIndicator.SetActive(false);
-        // this.characterBase.CharacterCard.SetActive(false);
     }
 
     private void DestroySkillsClone()

--- a/client/Assets/Scripts/CustomCharacter.cs
+++ b/client/Assets/Scripts/CustomCharacter.cs
@@ -38,8 +38,9 @@ public class CustomCharacter : Character
         this.ConditionState.ChangeState(CharacterStates.CharacterConditions.Dead);
         this.characterBase.Hitbox.SetActive(false);
         DestroySkillsClone();
-        this.characterBase.OrientationIndicator.SetActive(false);
-        this.characterBase.CharacterCard.SetActive(false);
+        this.characterBase.CanvasHolder.SetActive(false);
+        // this.characterBase.OrientationIndicator.SetActive(false);
+        // this.characterBase.CharacterCard.SetActive(false);
     }
 
     private void DestroySkillsClone()


### PR DESCRIPTION
## Motivation

When the player dies the stamina indicator was not desactivated

## Summary of changes

Desactivate canvasholder wich includes both stamina and player card when player is dead.

## How has this been tested?

Describe the steps you performed to test this PR.

## Test additions / changes

List tests added/updated.

## Checklist
- [ ] I have tested the changes locally.
- [ ] I self-reviewed the changes on GitHub, line by line.
- [ ] Tests have been added/updated.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] I have tested the changes in another devices.
  - [ ] Tested in iOS.
  - [ ] Tested in Android.
