### PR TITLE
Fixed orientation indicator overlapping

### DIFF
--- a/client/Assets/Prefabs/CharacterBase.prefab
+++ b/client/Assets/Prefabs/CharacterBase.prefab
@@ -154,6 +154,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8c27519de357b4dae962d7fcc6dc3470, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  hasTransparentMaterial: 0
   skinnedMeshRenderer: {fileID: 0}
   transparentMaterial: {fileID: 0}
 --- !u!1 &6615036954960681955
@@ -265,7 +266,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0.099999905}
+  m_AnchoredPosition: {x: 0, y: 0.25}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &5085971671319026984

--- a/client/Assets/Prefabs/Characters/H4ck.prefab
+++ b/client/Assets/Prefabs/Characters/H4ck.prefab
@@ -110,7 +110,7 @@ CharacterController:
   m_IsTrigger: 0
   m_Enabled: 1
   serializedVersion: 2
-  m_Height: 3.7
+  m_Height: 4
   m_Radius: 0.9
   m_SlopeLimit: 45
   m_StepOffset: 0.3


### PR DESCRIPTION
## Summary of changes
Raised character orientation game object to prevent terrain overlapping, especially the center circle.

## Reference
<img width="827" alt="image" src="https://github.com/lambdaclass/curse_of_mirra/assets/6811225/5bfa6715-e3d7-4db2-a618-3480909b4f8c">


## Checklist
- [ ] I have tested the changes locally.
- [ ] I self-reviewed the changes on GitHub, line by line.
- [ ] Tests have been added/updated.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] I have tested the changes in another devices.
  - [ ] Tested in iOS.
  - [ ] Tested in Android.
