### PR TITLE
Fix direction when moving

### DIFF
--- a/client/Assets/Scripts/Battle.cs
+++ b/client/Assets/Scripts/Battle.cs
@@ -417,7 +417,7 @@ public class Battle : MonoBehaviour
                 ulong skillOwner = gameProjectiles[i].Projectile.OwnerId;
 
                 SkillInfo info = skillInfoSet
-                    .Where(el => el.skillKey == projectileKey && el.ownerId == skillOwner )
+                    .Where(el => el.skillKey == projectileKey && el.ownerId == skillOwner)
                     .FirstOrDefault();
 
                 if (info != null)
@@ -585,6 +585,9 @@ public class Battle : MonoBehaviour
             }
         }
 
+        Direction direction = GetPlayerDirection(playerUpdate);
+        character.RotatePlayer(player, direction);
+
         Vector2 movementChange = new Vector2(xChange, yChange);
 
         // This magnitude allow us to not reconciliate the player's position if the change is too small
@@ -632,7 +635,7 @@ public class Battle : MonoBehaviour
 
             // FIXME: This is a temporary solution to solve unwanted player rotation until we handle movement blocking on backend
             // if the player is in attacking state, movement rotation from movement should be ignored
-            Direction direction = GetPlayerDirection(playerUpdate);
+            direction = GetPlayerDirection(playerUpdate);
 
             if (PlayerMovementAuthorized(player.GetComponent<CustomCharacter>()))
             {

--- a/client/Assets/Scripts/Battle.cs
+++ b/client/Assets/Scripts/Battle.cs
@@ -353,15 +353,15 @@ public class Battle : MonoBehaviour
         {
             case PlayerActionType.ExecutingSkill1:
                 currentPlayer.GetComponent<Skill1>().ExecuteFeedbacks(skillDuration, true);
-                character.RotatePlayer(currentPlayer, direction);
+                character.RotatePlayer(direction);
                 break;
             case PlayerActionType.ExecutingSkill2:
                 currentPlayer.GetComponent<Skill2>().ExecuteFeedbacks(skillDuration, true);
-                character.RotatePlayer(currentPlayer, direction);
+                character.RotatePlayer(direction);
                 break;
             case PlayerActionType.ExecutingSkill3:
                 currentPlayer.GetComponent<Skill3>().ExecuteFeedbacks(skillDuration, true);
-                character.RotatePlayer(currentPlayer, direction);
+                character.RotatePlayer(direction);
                 break;
         }
     }
@@ -585,9 +585,6 @@ public class Battle : MonoBehaviour
             }
         }
 
-        Direction direction = GetPlayerDirection(playerUpdate);
-        character.RotatePlayer(player, direction);
-
         Vector2 movementChange = new Vector2(xChange, yChange);
 
         // This magnitude allow us to not reconciliate the player's position if the change is too small
@@ -635,11 +632,11 @@ public class Battle : MonoBehaviour
 
             // FIXME: This is a temporary solution to solve unwanted player rotation until we handle movement blocking on backend
             // if the player is in attacking state, movement rotation from movement should be ignored
-            direction = GetPlayerDirection(playerUpdate);
+            Direction direction = GetPlayerDirection(playerUpdate);
 
             if (PlayerMovementAuthorized(player.GetComponent<CustomCharacter>()))
             {
-                character.RotatePlayer(player, direction);
+                character.RotatePlayer(direction);
             }
         }
 

--- a/client/Assets/Scripts/CustomCharacter.cs
+++ b/client/Assets/Scripts/CustomCharacter.cs
@@ -20,7 +20,7 @@ public class CustomCharacter : Character
         }
     }
 
-    public void RotatePlayer(GameObject player, Direction direction)
+    public void RotatePlayer(Direction direction)
     {
         CharacterOrientation3D characterOrientation = this.GetComponent<CharacterOrientation3D>();
         characterOrientation.ForcedRotation = true;

--- a/client/Assets/Scripts/CustomLevelManager.cs
+++ b/client/Assets/Scripts/CustomLevelManager.cs
@@ -169,9 +169,14 @@ public class CustomLevelManager : LevelManager
             newPlayer.CharacterHealth.MaximumHealth = player.Player.Health;
             newPlayer.name = "Player" + player.Id;
             newPlayer.PlayerID = player.Id.ToString();
-            SetPlayerHealthBar(GameServerConnectionManager.Instance.playerId == player.Id, newPlayer);
+            SetPlayerHealthBar(
+                GameServerConnectionManager.Instance.playerId == player.Id,
+                newPlayer
+            );
             GameServerConnectionManager.Instance.players.Add(newPlayer.gameObject);
             this.Players.Add(newPlayer);
+
+            newPlayer.RotatePlayer(player.Direction);
         }
         this.PlayerPrefabs = (this.Players).ToArray();
     }
@@ -300,15 +305,15 @@ public class CustomLevelManager : LevelManager
         }
     }
 
-    private void SetPlayerHealthBar(bool isClientId ,Character character)
+    private void SetPlayerHealthBar(bool isClientId, Character character)
     {
-            Image healthBarFront = character
-                .GetComponent<MMHealthBar>()
-                .TargetProgressBar
-                .ForegroundBar
-                .GetComponent<Image>();
-           
-                healthBarFront.color = isClientId ? Utils.healthBarRed :  Utils.healthBarGreen;
+        Image healthBarFront = character
+            .GetComponent<MMHealthBar>()
+            .TargetProgressBar
+            .ForegroundBar
+            .GetComponent<Image>();
+
+        healthBarFront.color = isClientId ? Utils.healthBarRed : Utils.healthBarGreen;
     }
 
     private IEnumerator ShowDeathSplash(GameObject player)


### PR DESCRIPTION
Closes #[issue]

## Motivation

The player's direction was wrong because added a threshold to the magnitude of the movement between frames.

## Checklist
- [x] I have tested the changes locally.
- [ ] I self-reviewed the changes on GitHub, line by line.
- [ ] Tests have been added/updated.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] I have tested the changes in another devices.
  - [ ] Tested in iOS.
  - [ ] Tested in Android.
