### PR TITLE
Hide smoke effect in Survive text

### DIFF
--- a/client/Assets/Prefabs/Camera/CameraUI.prefab
+++ b/client/Assets/Prefabs/Camera/CameraUI.prefab
@@ -1751,7 +1751,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &9123393008415500373
 RectTransform:
   m_ObjectHideFlags: 0
@@ -1761,7 +1761,7 @@ RectTransform:
   m_GameObject: {fileID: 80749578850922491}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.6911447, y: 0.6911447, z: 0.6911447}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 7442518337301163166}
@@ -5876,7 +5876,6 @@ MonoBehaviour:
   playersBottomTable: {fileID: 1796390706201602963}
   prepareCoin: {fileID: 5769132581105517621}
   surviveText: {fileID: 4707298941903163517}
-  smokeEffectBehind: {fileID: 3559510225174257283}
   countDown: {fileID: 8354045121928496173}
   cinemachineVirtualCamera: {fileID: 114129316014370704}
 --- !u!225 &4615091370588803898
@@ -8366,7 +8365,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &7768122133472710469
 RectTransform:
   m_ObjectHideFlags: 0
@@ -8376,7 +8375,7 @@ RectTransform:
   m_GameObject: {fileID: 3056413433569517697}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.6911447, y: 0.6911447, z: 0.6911447}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4410802374239376205}
@@ -14235,7 +14234,7 @@ ParticleSystemRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3539763238743800420}
-  m_Enabled: 0
+  m_Enabled: 1
   m_CastShadows: 1
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1
@@ -19062,7 +19061,7 @@ ParticleSystemRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3559510225174257283}
-  m_Enabled: 0
+  m_Enabled: 1
   m_CastShadows: 1
   m_ReceiveShadows: 0
   m_DynamicOccludee: 1

--- a/client/Assets/Scripts/UI/PrepareForBattleAnimations.cs
+++ b/client/Assets/Scripts/UI/PrepareForBattleAnimations.cs
@@ -24,8 +24,7 @@ public class PrepareForBattleAnimations : MonoBehaviour
         playersTopTable,
         playersBottomTable,
         prepareCoin,
-        surviveText,
-        smokeEffectBehind;
+        surviveText;
 
     [SerializeField]
     TextMeshProUGUI countDown;
@@ -138,12 +137,10 @@ public class PrepareForBattleAnimations : MonoBehaviour
     IEnumerator SurviveAnimation()
     {
         surviveContainer.GetComponent<CanvasGroup>().DOFade(1, .1f);
-        smokeEffectBehind.SetActive(true);
         surviveTextContainer.transform.DOScale(originalSurviveScale + 1.5f, .4f);
         yield return new WaitForSeconds(1.3f);
         surviveText.GetComponent<CanvasGroup>().DOFade(0, .1f);
         yield return new WaitForSeconds(.3f);
-        smokeEffectBehind.SetActive(false);
         surviveContainer.GetComponent<CanvasGroup>().DOFade(0, .25f);
         GetComponent<CanvasGroup>().DOFade(0, .25f);
         battleScreen.GetComponent<CanvasGroup>().DOFade(1, .25f);


### PR DESCRIPTION
Until issue #1511 is solved

## Motivation

The smoke effect was outdated

## Summary of changes

This PR hides the violet smoke effect until this animation is updated.
The effect has been hidden and not deleted to save time during the reimplementation process.

## How has this been tested?

Start a match and play close attention to the survive text. Since this is not the final look and a refactor is coming soon I recommend reviewing if this doesn't bother the eye so much until this is solved

## Checklist
- [x] I have tested the changes locally.
- [x] I self-reviewed the changes on GitHub, line by line.
- [ ] Tests have been added/updated.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] I have tested the changes in another devices.
  - [ ] Tested in iOS.
  - [ ] Tested in Android.
