### PR TITLE
PostProcessing not affecting UI in game

### DIFF
--- a/client/Assets/Prefabs/AimDirection.prefab
+++ b/client/Assets/Prefabs/AimDirection.prefab
@@ -10,7 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 6787156628499368461}
   - component: {fileID: 6738943573842909003}
-  m_Layer: 10
+  m_Layer: 24
   m_Name: AimDirection
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -74,7 +74,7 @@ GameObject:
   - component: {fileID: 6395700585140466295}
   - component: {fileID: 2574016039783710474}
   - component: {fileID: 8207894888625631606}
-  m_Layer: 0
+  m_Layer: 24
   m_Name: Cone
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/client/Assets/Prefabs/Camera/CameraUI.prefab
+++ b/client/Assets/Prefabs/Camera/CameraUI.prefab
@@ -615,7 +615,7 @@ GameObject:
   - component: {fileID: 8842644193255156245}
   - component: {fileID: 6896190933309054917}
   - component: {fileID: 1671527595}
-  m_Layer: 10
+  m_Layer: 19
   m_Name: MainCamera
   m_TagString: MainCamera
   m_Icon: {fileID: 0}
@@ -633,7 +633,8 @@ Transform:
   m_LocalPosition: {x: -9, y: 25.7, z: -28}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
+  m_Children:
+  - {fileID: 4400441287521086557}
   m_Father: {fileID: 4847471433058572}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -668,7 +669,7 @@ Camera:
   m_Depth: 1
   m_CullingMask:
     serializedVersion: 2
-    m_Bits: 4294967295
+    m_Bits: 16777047
   m_RenderingPath: 3
   m_TargetTexture: {fileID: 0}
   m_TargetDisplay: 0
@@ -758,7 +759,8 @@ MonoBehaviour:
   m_RequiresDepthTextureOption: 2
   m_RequiresOpaqueTextureOption: 2
   m_CameraType: 0
-  m_Cameras: []
+  m_Cameras:
+  - {fileID: 6757346034397394627}
   m_RendererIndex: -1
   m_VolumeLayerMask:
     serializedVersion: 2
@@ -810,7 +812,7 @@ GameObject:
   - component: {fileID: 5150186080710848351}
   - component: {fileID: 4124095054134912735}
   - component: {fileID: 9207843207175784621}
-  m_Layer: 0
+  m_Layer: 20
   m_Name: CM vcam1
   m_TagString: MainCamera
   m_Icon: {fileID: 0}
@@ -1211,7 +1213,7 @@ GameObject:
   - component: {fileID: 2053005125}
   - component: {fileID: 5269512940582173692}
   - component: {fileID: 2856279044554654236}
-  m_Layer: 0
+  m_Layer: 21
   m_Name: UICamera
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1409,7 +1411,7 @@ GameObject:
   - component: {fileID: 4290419465729776}
   - component: {fileID: 114794669332985446}
   - component: {fileID: 114329137893650930}
-  m_Layer: 0
+  m_Layer: 20
   m_Name: cm
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -19550,6 +19552,124 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &3978906254358513391
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4400441287521086557}
+  - component: {fileID: 6757346034397394627}
+  - component: {fileID: 2708474910330090943}
+  - component: {fileID: 248204092908166071}
+  m_Layer: 19
+  m_Name: NoPostProcessCamera
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4400441287521086557
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3978906254358513391}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4195150596186120}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!20 &6757346034397394627
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3978906254358513391}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_FocalLength: 50
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.1
+  far clip plane: 140
+  field of view: 35
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 16777216
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 0
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!81 &2708474910330090943
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3978906254358513391}
+  m_Enabled: 1
+--- !u!114 &248204092908166071
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3978906254358513391}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a79441f348de89743a2939f4d699eac1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_RenderShadows: 1
+  m_RequiresDepthTextureOption: 2
+  m_RequiresOpaqueTextureOption: 2
+  m_CameraType: 1
+  m_Cameras: []
+  m_RendererIndex: -1
+  m_VolumeLayerMask:
+    serializedVersion: 2
+    m_Bits: 1
+  m_VolumeTrigger: {fileID: 0}
+  m_VolumeFrameworkUpdateModeOption: 2
+  m_RenderPostProcessing: 0
+  m_Antialiasing: 0
+  m_AntialiasingQuality: 2
+  m_StopNaN: 0
+  m_Dithering: 0
+  m_ClearDepth: 0
+  m_AllowXRRendering: 1
+  m_RequiresDepthTexture: 0
+  m_RequiresColorTexture: 0
+  m_Version: 2
 --- !u!1 &4002431645116009082
 GameObject:
   m_ObjectHideFlags: 0

--- a/client/Assets/Prefabs/CharacterBase.prefab
+++ b/client/Assets/Prefabs/CharacterBase.prefab
@@ -11,7 +11,7 @@ GameObject:
   - component: {fileID: 2682950895344503891}
   - component: {fileID: 8790554508866863196}
   - component: {fileID: 2664940261528478740}
-  m_Layer: 0
+  m_Layer: 24
   m_Name: Orientator
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -87,7 +87,7 @@ GameObject:
   - component: {fileID: 1377340570206829633}
   - component: {fileID: 6284103280827666314}
   - component: {fileID: 1743729574858777773}
-  m_Layer: 0
+  m_Layer: 24
   m_Name: CharacterBase
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -169,7 +169,7 @@ GameObject:
   - component: {fileID: 8173465752018876278}
   - component: {fileID: 7700158324449265958}
   - component: {fileID: 5535320627302818549}
-  m_Layer: 0
+  m_Layer: 24
   m_Name: CanvasHolder
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -241,7 +241,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4861600391620598459}
   - component: {fileID: 5085971671319026984}
-  m_Layer: 0
+  m_Layer: 24
   m_Name: OrientationIndicator
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/client/Assets/Prefabs/CharacterCard.prefab
+++ b/client/Assets/Prefabs/CharacterCard.prefab
@@ -10,7 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 8206914607531316031}
   - component: {fileID: 4738216627854206166}
-  m_Layer: 0
+  m_Layer: 24
   m_Name: CharacterCard
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/client/Assets/Prefabs/Feedbacks/DamageFeedback.prefab
+++ b/client/Assets/Prefabs/Feedbacks/DamageFeedback.prefab
@@ -10,7 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1427908502938560624}
   - component: {fileID: 1438067562074111280}
-  m_Layer: 10
+  m_Layer: 0
   m_Name: DamageFeedback
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/client/Assets/Prefabs/Feedbacks/HitFeedback.prefab
+++ b/client/Assets/Prefabs/Feedbacks/HitFeedback.prefab
@@ -10,7 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1427908502938560624}
   - component: {fileID: 1438067562074111280}
-  m_Layer: 10
+  m_Layer: 0
   m_Name: HitFeedback
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/client/Assets/Prefabs/HealthBar.prefab
+++ b/client/Assets/Prefabs/HealthBar.prefab
@@ -11,7 +11,7 @@ GameObject:
   - component: {fileID: 224000012709266672}
   - component: {fileID: 222000010248075858}
   - component: {fileID: 114000014199762522}
-  m_Layer: 5
+  m_Layer: 24
   m_Name: HealthBarBackground
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -86,7 +86,7 @@ GameObject:
   m_Component:
   - component: {fileID: 224000010736761302}
   - component: {fileID: 114091369736583034}
-  m_Layer: 5
+  m_Layer: 24
   m_Name: HealthBar
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -358,7 +358,7 @@ GameObject:
   - component: {fileID: 224000010139907416}
   - component: {fileID: 222000013370391236}
   - component: {fileID: 114000011583259746}
-  m_Layer: 5
+  m_Layer: 24
   m_Name: HealthBarFront
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -434,7 +434,7 @@ GameObject:
   - component: {fileID: 9221185991651748511}
   - component: {fileID: 378794226665798086}
   - component: {fileID: 2700575606625810454}
-  m_Layer: 5
+  m_Layer: 24
   m_Name: HealthBarMiddle
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -510,7 +510,7 @@ GameObject:
   - component: {fileID: 3227939929638589739}
   - component: {fileID: 1732548766338125319}
   - component: {fileID: 1728158608909436928}
-  m_Layer: 5
+  m_Layer: 24
   m_Name: HealthBarFade
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/client/Assets/Prefabs/Hitbox.prefab
+++ b/client/Assets/Prefabs/Hitbox.prefab
@@ -9,7 +9,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 506244918869636381}
-  m_Layer: 10
+  m_Layer: 0
   m_Name: Hitbox
   m_TagString: Hitbox
   m_Icon: {fileID: 0}

--- a/client/Assets/Prefabs/Player Name.prefab
+++ b/client/Assets/Prefabs/Player Name.prefab
@@ -13,7 +13,7 @@ GameObject:
   - component: {fileID: 5893176695115860107}
   - component: {fileID: 3096859426901363567}
   - component: {fileID: 9072743118232334869}
-  m_Layer: 0
+  m_Layer: 24
   m_Name: Player Name
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/client/Assets/Prefabs/PowerUps.prefab
+++ b/client/Assets/Prefabs/PowerUps.prefab
@@ -9,7 +9,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 7532905112430061776}
-  m_Layer: 0
+  m_Layer: 24
   m_Name: PowerUps
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -49,7 +49,7 @@ GameObject:
   - component: {fileID: 2202432717747513465}
   - component: {fileID: 110337315952864537}
   - component: {fileID: 5257089240443073153}
-  m_Layer: 0
+  m_Layer: 24
   m_Name: PowerUpIcon
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -126,7 +126,7 @@ GameObject:
   - component: {fileID: 7372080326581831557}
   - component: {fileID: 6801753508709228941}
   - component: {fileID: 2690385114274865769}
-  m_Layer: 0
+  m_Layer: 24
   m_Name: PowerUpCount
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/client/Assets/Prefabs/SkillRange.prefab
+++ b/client/Assets/Prefabs/SkillRange.prefab
@@ -11,7 +11,7 @@ GameObject:
   - component: {fileID: 5449516806302885538}
   - component: {fileID: 3404867471729547236}
   - component: {fileID: 7859490951503353613}
-  m_Layer: 0
+  m_Layer: 24
   m_Name: SkillRangePlane
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -92,7 +92,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1419613310121612150}
-  m_Layer: 0
+  m_Layer: 24
   m_Name: SkillRange
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/client/Assets/Prefabs/StaminaCharges.prefab
+++ b/client/Assets/Prefabs/StaminaCharges.prefab
@@ -12,7 +12,7 @@ GameObject:
   - component: {fileID: 7308723003955542593}
   - component: {fileID: 2863616589487620225}
   - component: {fileID: 5754809696113213169}
-  m_Layer: 7
+  m_Layer: 24
   m_Name: Fill Stamina 3
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -103,7 +103,7 @@ GameObject:
   - component: {fileID: 79755414717119550}
   - component: {fileID: 5867108155140409948}
   - component: {fileID: 7642295035784800999}
-  m_Layer: 7
+  m_Layer: 24
   m_Name: Fill Stamina 1
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -193,7 +193,7 @@ GameObject:
   - component: {fileID: 1094073829173155169}
   - component: {fileID: 4950394529710162305}
   - component: {fileID: 4294573196067237231}
-  m_Layer: 7
+  m_Layer: 24
   m_Name: Stamina3
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -270,7 +270,7 @@ GameObject:
   - component: {fileID: 5169390739512801972}
   - component: {fileID: 1264891647764918612}
   - component: {fileID: 6867229475502675876}
-  m_Layer: 7
+  m_Layer: 24
   m_Name: Stamina2
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -348,7 +348,7 @@ GameObject:
   - component: {fileID: 5539191568022653863}
   - component: {fileID: 5145983503463320817}
   - component: {fileID: 6743273946512125365}
-  m_Layer: 7
+  m_Layer: 24
   m_Name: Fill Stamina 2
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -438,7 +438,7 @@ GameObject:
   - component: {fileID: 4095522184466235866}
   - component: {fileID: 5534929111570447281}
   - component: {fileID: 5333299199419601594}
-  m_Layer: 7
+  m_Layer: 24
   m_Name: Stamina1
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -514,7 +514,7 @@ GameObject:
   m_Component:
   - component: {fileID: 8563174794001401240}
   - component: {fileID: 2964130064261950093}
-  m_Layer: 7
+  m_Layer: 24
   m_Name: StaminaCharges
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -564,4 +564,4 @@ MonoBehaviour:
   - {fileID: 5867108155140409948}
   - {fileID: 5145983503463320817}
   - {fileID: 2863616589487620225}
-  shake: 0
+  playingFeedback: 0

--- a/client/Assets/Prefabs/UI/DeathSplash.prefab
+++ b/client/Assets/Prefabs/UI/DeathSplash.prefab
@@ -1626,7 +1626,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1334923128975001696}
   - component: {fileID: 881100692547573838}
-  m_Layer: 7
+  m_Layer: 0
   m_Name: Model
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/client/Assets/VFX-Tools/PIngle_VFX/AimIndicator/AimIndicator.prefab
+++ b/client/Assets/VFX-Tools/PIngle_VFX/AimIndicator/AimIndicator.prefab
@@ -11,7 +11,7 @@ GameObject:
   - component: {fileID: 3897031586263953030}
   - component: {fileID: 124642845061701923}
   - component: {fileID: 2764688213454001641}
-  m_Layer: 0
+  m_Layer: 24
   m_Name: AimIndicator
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/client/Assets/VFX-Tools/PIngle_VFX/Arrow/ArrowPlane.prefab
+++ b/client/Assets/VFX-Tools/PIngle_VFX/Arrow/ArrowPlane.prefab
@@ -11,7 +11,7 @@ GameObject:
   - component: {fileID: 4267464509048176532}
   - component: {fileID: 907140837952466993}
   - component: {fileID: 3130626816695911675}
-  m_Layer: 0
+  m_Layer: 24
   m_Name: ArrowPlane
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -95,7 +95,7 @@ GameObject:
   - component: {fileID: 5936082863813509140}
   - component: {fileID: 2246689485714411586}
   - component: {fileID: 5794120047626104820}
-  m_Layer: 0
+  m_Layer: 24
   m_Name: ArrowPlaneArrow
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/client/Assets/VFX-Tools/PIngle_VFX/SectorOutliner/SectorOutliner.prefab
+++ b/client/Assets/VFX-Tools/PIngle_VFX/SectorOutliner/SectorOutliner.prefab
@@ -11,7 +11,7 @@ GameObject:
   - component: {fileID: 2445171733257327780}
   - component: {fileID: 2445171733257327786}
   - component: {fileID: 2445171733257327781}
-  m_Layer: 0
+  m_Layer: 24
   m_Name: 5degree_sector_border_left
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -94,7 +94,7 @@ GameObject:
   - component: {fileID: 431544031841102448}
   - component: {fileID: 6269750010586548929}
   - component: {fileID: 2042008111552600846}
-  m_Layer: 0
+  m_Layer: 24
   m_Name: 5degree_sector_border_right
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -176,7 +176,7 @@ GameObject:
   m_Component:
   - component: {fileID: 8034528553866079081}
   - component: {fileID: 8034528553866079086}
-  m_Layer: 0
+  m_Layer: 24
   m_Name: SectorOutliner
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -225,7 +225,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1753387737924428899}
-  m_Layer: 0
+  m_Layer: 24
   m_Name: InverseRoot
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/client/Assets/VFX-Tools/PIngle_VFX/Surface/Surface.prefab
+++ b/client/Assets/VFX-Tools/PIngle_VFX/Surface/Surface.prefab
@@ -11,7 +11,7 @@ GameObject:
   - component: {fileID: 5830249199179388121}
   - component: {fileID: 7441898582411107196}
   - component: {fileID: 4657311477907599286}
-  m_Layer: 0
+  m_Layer: 24
   m_Name: Surface
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/client/ProjectSettings/TagManager.asset
+++ b/client/ProjectSettings/TagManager.asset
@@ -11,11 +11,12 @@ TagManager:
   - NoMask
   - Hitbox
   - ZoneParticle
+  - UmaSoul1
   layers:
   - Default
   - TransparentFX
   - Ignore Raycast
-  - 
+  - NoPostProcess
   - Water
   - UI
   - ProjectileObstacles
@@ -36,7 +37,7 @@ TagManager:
   - Camera3
   - Camera4
   - ZoneParticle
-  - 
+  - NoPostProcess
   - 
   - 
   - 


### PR DESCRIPTION
Closes #1532 

## Motivation

The UI in game was changing their color because it was affected by post processing

## Summary of changes

The camera layers were wrong so that was fixed

A new layer called "NoPostProcess" was created and applied to all desired elements we don't want to be affected by the post processing component in game

Check:
- stamina indicators
- orientation indication of player
- player name
- health bar
- skill indicators

The reason for not applying that to the feedbacks is I believe the postprocessing there makes the feedback feel more as if they were part of the world and character instead of being clearly in another layer.

## How has this been tested?

In main you can see this:

https://github.com/lambdaclass/curse_of_mirra/assets/82987608/93a42be3-b212-4f59-a808-08dd8206c35a

Take into account you can't see the fix in the scene but it does apply in the simulation and mobile build:

[ Top part > Scene // Bottom part > Simulation ]
<img width="569" alt="Captura de pantalla 2024-03-01 a la(s) 13 26 56" src="https://github.com/lambdaclass/curse_of_mirra/assets/82987608/101b9e79-547a-42e6-bc3c-7222dee54d3c">

[Mobile build]
![Screenshot_20240301_135930_client](https://github.com/lambdaclass/curse_of_mirra/assets/82987608/6285d63b-baa7-431a-b75f-e31941289e5e)


## Test additions / changes

List tests added/updated.

## Checklist
- [x] I have tested the changes locally.
- [x] I self-reviewed the changes on GitHub, line by line.
- [ ] Tests have been added/updated.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [x] I have tested the changes in another devices.
  - [ ] Tested in iOS.
  - [x] Tested in Android.
