### PR TITLE
Fix uma's material render face

### DIFF
--- a/client/Assets/Materials/Characters/Uma/Updated/Uma_txt.mat
+++ b/client/Assets/Materials/Characters/Uma/Updated/Uma_txt.mat
@@ -30,7 +30,7 @@ Material:
   m_InvalidKeywords: []
   m_LightmapFlags: 1
   m_EnableInstancingVariants: 0
-  m_DoubleSidedGI: 0
+  m_DoubleSidedGI: 1
   m_CustomRenderQueue: -1
   stringTagMap:
     RenderType: Opaque
@@ -101,7 +101,7 @@ Material:
     - _BumpScale: 1
     - _ClearCoatMask: 0
     - _ClearCoatSmoothness: 0
-    - _Cull: 2
+    - _Cull: 0
     - _Cutoff: 0.5
     - _DetailAlbedoMapScale: 1
     - _DetailNormalMapScale: 1


### PR DESCRIPTION
## Motivation

In both main and character info screens Uma's model was only rendering the front face of the material. This resulted in the following error inside her sleeves: 

![IMG_3798](https://github.com/lambdaclass/curse_of_mirra/assets/82987608/855abc69-ba4d-4ecc-abdd-f4193415398b)

## Summary of changes

Fixed the material config

<img width="1405" alt="Captura de pantalla 2024-03-12 a la(s) 16 24 51" src="https://github.com/lambdaclass/curse_of_mirra/assets/82987608/e0cc21f9-e0a7-4aaa-a198-90da2452fdf1">


## Checklist
- [ ] I have tested the changes locally.
- [ ] I self-reviewed the changes on GitHub, line by line.
- [ ] Tests have been added/updated.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] I have tested the changes in another devices.
  - [ ] Tested in iOS.
  - [ ] Tested in Android.
