### PR TITLE
Play game button

### DIFF
--- a/client/Assets/Scripts/LobbyManager.cs
+++ b/client/Assets/Scripts/LobbyManager.cs
@@ -1,6 +1,4 @@
-using System;
 using System.Collections;
-using MoreMountains.Tools;
 using MoreMountains.TopDownEngine;
 using UnityEngine;
 using UnityEngine.SceneManagement;
@@ -11,26 +9,12 @@ public class LobbyManager : LevelSelector
     private const string LOBBY_SCENE_NAME = "Lobby";
     private const string MAIN_SCENE_NAME = "MainScreen";
     private const string LOBBIES_BACKGROUND_MUSIC = "LobbiesBackgroundMusic";
-    bool loadScene = false;
 
     public static string LevelSelected;
 
     void Start()
     {
         StartCoroutine(WaitForLobbyJoin());
-    }
-
-    private void Update()
-    {
-        if (
-            !string.IsNullOrEmpty(SessionParameters.GameId)
-            && SceneManager.GetActiveScene().name == LOBBY_SCENE_NAME
-            && loadScene
-        )
-        {
-            Debug.Log("Loading battle scene");
-            SceneManager.LoadScene(BATTLE_SCENE_NAME);
-        }
     }
 
     public void BackToLobbyFromGame()
@@ -64,11 +48,13 @@ public class LobbyManager : LevelSelector
 
     public IEnumerator WaitForLobbyJoin()
     {
+        yield return new WaitUntil(() => SceneManager.GetActiveScene().name == LOBBY_SCENE_NAME);
         ServerConnection.Instance.JoinLobby();
         yield return new WaitUntil(
-            () => !string.IsNullOrEmpty(ServerConnection.Instance.LobbySession)
+            () =>
+                !string.IsNullOrEmpty(ServerConnection.Instance.LobbySession)
+                && !string.IsNullOrEmpty(SessionParameters.GameId)
         );
-        loadScene = true;
-        Debug.Log("Load battle scene");
+        SceneManager.LoadScene(BATTLE_SCENE_NAME);
     }
 }

--- a/client/Assets/Scripts/LobbyManager.cs
+++ b/client/Assets/Scripts/LobbyManager.cs
@@ -11,6 +11,7 @@ public class LobbyManager : LevelSelector
     private const string LOBBY_SCENE_NAME = "Lobby";
     private const string MAIN_SCENE_NAME = "MainScreen";
     private const string LOBBIES_BACKGROUND_MUSIC = "LobbiesBackgroundMusic";
+    bool loadScene = false;
 
     public static string LevelSelected;
 
@@ -24,6 +25,7 @@ public class LobbyManager : LevelSelector
         if (
             !string.IsNullOrEmpty(SessionParameters.GameId)
             && SceneManager.GetActiveScene().name == LOBBY_SCENE_NAME
+            && loadScene
         )
         {
             Debug.Log("Loading battle scene");
@@ -66,6 +68,7 @@ public class LobbyManager : LevelSelector
         yield return new WaitUntil(
             () => !string.IsNullOrEmpty(ServerConnection.Instance.LobbySession)
         );
-        Debug.Log("Loading battle scene");
+        loadScene = true;
+        Debug.Log("Load battle scene");
     }
 }

--- a/client/Assets/Scripts/LobbyManager.cs
+++ b/client/Assets/Scripts/LobbyManager.cs
@@ -14,10 +14,15 @@ public class LobbyManager : LevelSelector
 
     public static string LevelSelected;
 
+    void Start()
+    {
+        StartCoroutine(WaitForLobbyJoin());
+    }
+
     private void Update()
     {
         if (
-            !String.IsNullOrEmpty(SessionParameters.GameId)
+            !string.IsNullOrEmpty(SessionParameters.GameId)
             && SceneManager.GetActiveScene().name == LOBBY_SCENE_NAME
         )
         {
@@ -53,5 +58,14 @@ public class LobbyManager : LevelSelector
         // ServerConnection.Instance.Init();
         this.LevelName = MAIN_SCENE_NAME;
         SceneManager.LoadScene(this.LevelName);
+    }
+
+    public IEnumerator WaitForLobbyJoin()
+    {
+        ServerConnection.Instance.JoinLobby();
+        yield return new WaitUntil(
+            () => !string.IsNullOrEmpty(ServerConnection.Instance.LobbySession)
+        );
+        Debug.Log("Loading battle scene");
     }
 }

--- a/client/Assets/Scripts/MainManager.cs
+++ b/client/Assets/Scripts/MainManager.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections;
 using MoreMountains.TopDownEngine;
 using UnityEngine;
 using UnityEngine.SceneManagement;
@@ -16,17 +14,6 @@ public class MainManager : LevelSelector
 
     public void JoinLobby()
     {
-        StartCoroutine(WaitForLobbyJoin());
-    }
-
-    public IEnumerator WaitForLobbyJoin()
-    {
-        ServerConnection.Instance.JoinLobby();
-        yield return new WaitUntil(
-            () =>
-                !string.IsNullOrEmpty(ServerConnection.Instance.LobbySession)
-                // && ServerConnection.Instance.playerId != UInt64.MaxValue
-        );
         SceneManager.LoadScene("Lobby");
     }
 }


### PR DESCRIPTION
Closes #1527 

## Motivation

Instead of adding a visual feedback for an unexpected behavior the button's use was updated.

## Summary of changes

The button now automatically sends the user to the lobby. This prevents the user from waiting in the main screen confused if the play button's action went through or not. Then the user waits for a match and players in the lobby (as expected)

## How has this been tested?

Try using mobile data to emulate different types of server connection. Test all available servers including local an this should work as described.

## Checklist
- [x] I have tested the changes locally.
- [x] I self-reviewed the changes on GitHub, line by line.
- [ ] Tests have been added/updated.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] I have tested the changes in another devices.
  - [ ] Tested in iOS.
  - [ ] Tested in Android.
