### PR TITLE
[GH-1636] Fix bug in Hack Slingshot prefab

### DIFF
--- a/client/Assets/Prefabs/Projectiles/HackMultishot.prefab
+++ b/client/Assets/Prefabs/Projectiles/HackMultishot.prefab
@@ -15030,7 +15030,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   projectileInfo: {fileID: 11400000, guid: e3bb47ddbb21e4eb1867979ade7a9d01, type: 2}
   projectileElement: {fileID: 6670668704897285037}
-  trailRenderer: {fileID: 0}
   trail: {fileID: 3012811428108994762, guid: 248632c7ddad04a378b2ee224dac472b, type: 3}
   isTrailEnabled: 1
 --- !u!1 &6670668704897285037

--- a/client/Assets/Prefabs/Projectiles/Valtimer_Animatter_Projectile.prefab
+++ b/client/Assets/Prefabs/Projectiles/Valtimer_Animatter_Projectile.prefab
@@ -9820,7 +9820,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   projectileInfo: {fileID: 11400000, guid: 2d76ad506ce94df4586d3b8ebd9c1705, type: 2}
   projectileElement: {fileID: 2775624661060570538}
-  trailRenderer: {fileID: 2134725692421730995}
   trail: {fileID: 755081095622180596, guid: b8405f61330584c37b044c97b5a9c748, type: 3}
   isTrailEnabled: 1
 --- !u!1 &6402173562397493826
@@ -19625,12 +19624,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: b8405f61330584c37b044c97b5a9c748, type: 3}
---- !u!96 &2134725692421730995 stripped
-TrailRenderer:
-  m_CorrespondingSourceObject: {fileID: 6654940755162682982, guid: b8405f61330584c37b044c97b5a9c748,
-    type: 3}
-  m_PrefabInstance: {fileID: 4754403656308073685}
-  m_PrefabAsset: {fileID: 0}
 --- !u!4 &6165937611657679030 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 1471207553598501987, guid: b8405f61330584c37b044c97b5a9c748,

--- a/client/Assets/Scripts/Projectiles/SkillProjectile.cs
+++ b/client/Assets/Scripts/Projectiles/SkillProjectile.cs
@@ -9,9 +9,6 @@ public class SkillProjectile : MonoBehaviour
     [SerializeField]
     GameObject projectileElement;
 
-    [SerializeField]
-    TrailRenderer trailRenderer;
-
     private IEnumerator removeTrailSoftCor = null;
     private bool isUpdatingPosition = true;
 


### PR DESCRIPTION
Closes #1636

## Motivation
The field trailRenderer from the SkillProjectile class is not being used and it is causing Hack Slingshot prefab to be modified every time at leas one Hack is created for the battle. 

## Summary of changes
Deleted the unused field from the class.

## Checklist
- [x] I have tested the changes locally.
- [x] I self-reviewed the changes on GitHub, line by line.
- [ ] Tests have been added/updated.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] I have tested the changes in another devices.
  - [ ] Tested in iOS.
  - [ ] Tested in Android.
