### PR TITLE
[VFX] Added VFX Graph prewarmer

### DIFF
--- a/client/Assets/Prefabs/Managers/BattleManagers.prefab
+++ b/client/Assets/Prefabs/Managers/BattleManagers.prefab
@@ -30,9 +30,85 @@ Transform:
   m_Children:
   - {fileID: 8472880970067065813}
   - {fileID: 8472880968890490897}
+  - {fileID: 8619615575407823008}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1573143136919045111
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8472880969195610299}
+    m_Modifications:
+    - target: {fileID: 4837644246978273391, guid: 8fba8c5aea162c246b9eb5f55a261340,
+        type: 3}
+      propertyPath: m_Name
+      value: VFXGraphPrewarmer
+      objectReference: {fileID: 0}
+    - target: {fileID: 7083014235004652375, guid: 8fba8c5aea162c246b9eb5f55a261340,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 7083014235004652375, guid: 8fba8c5aea162c246b9eb5f55a261340,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7083014235004652375, guid: 8fba8c5aea162c246b9eb5f55a261340,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7083014235004652375, guid: 8fba8c5aea162c246b9eb5f55a261340,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7083014235004652375, guid: 8fba8c5aea162c246b9eb5f55a261340,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7083014235004652375, guid: 8fba8c5aea162c246b9eb5f55a261340,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7083014235004652375, guid: 8fba8c5aea162c246b9eb5f55a261340,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7083014235004652375, guid: 8fba8c5aea162c246b9eb5f55a261340,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7083014235004652375, guid: 8fba8c5aea162c246b9eb5f55a261340,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7083014235004652375, guid: 8fba8c5aea162c246b9eb5f55a261340,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7083014235004652375, guid: 8fba8c5aea162c246b9eb5f55a261340,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 8fba8c5aea162c246b9eb5f55a261340, type: 3}
+--- !u!4 &8619615575407823008 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7083014235004652375, guid: 8fba8c5aea162c246b9eb5f55a261340,
+    type: 3}
+  m_PrefabInstance: {fileID: 1573143136919045111}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &1725062584226539890
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/client/Assets/Prefabs/Managers/VFXGraphPrewarmer.prefab
+++ b/client/Assets/Prefabs/Managers/VFXGraphPrewarmer.prefab
@@ -1,0 +1,193 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &3932248327810658394
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3932248327810658397}
+  m_Layer: 0
+  m_Name: Root
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3932248327810658397
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3932248327810658394}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -1000, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1134205425221542703}
+  m_Father: {fileID: 7083014235004652375}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4837644246978273391
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7083014235004652375}
+  - component: {fileID: 428681550573616036}
+  m_Layer: 0
+  m_Name: VFXGraphPrewarmer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7083014235004652375
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4837644246978273391}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3932248327810658397}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &428681550573616036
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4837644246978273391}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 39d2632c095b01b43b2f981bc9e3daaf, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  vfx_graph_holder: {fileID: 11400000, guid: 919b8848c8dc8834585d3f32c2d34579, type: 2}
+  spawn_root: {fileID: 3932248327810658397}
+  camera: {fileID: 854950432110834686}
+  start_frames_delay: 5
+  interval_frames_delay: 5
+--- !u!1 &7132059960089125488
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1134205425221542703}
+  - component: {fileID: 854950432110834686}
+  - component: {fileID: 2989404705711112027}
+  m_Layer: 0
+  m_Name: Camera
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1134205425221542703
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7132059960089125488}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -17.3}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3932248327810658397}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!20 &854950432110834686
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7132059960089125488}
+  m_Enabled: 0
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_FocalLength: 50
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: -10
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!114 &2989404705711112027
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7132059960089125488}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a79441f348de89743a2939f4d699eac1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_RenderShadows: 1
+  m_RequiresDepthTextureOption: 2
+  m_RequiresOpaqueTextureOption: 2
+  m_CameraType: 0
+  m_Cameras: []
+  m_RendererIndex: -1
+  m_VolumeLayerMask:
+    serializedVersion: 2
+    m_Bits: 1
+  m_VolumeTrigger: {fileID: 0}
+  m_VolumeFrameworkUpdateModeOption: 2
+  m_RenderPostProcessing: 0
+  m_Antialiasing: 0
+  m_AntialiasingQuality: 2
+  m_StopNaN: 0
+  m_Dithering: 0
+  m_ClearDepth: 1
+  m_AllowXRRendering: 1
+  m_RequiresDepthTexture: 0
+  m_RequiresColorTexture: 0
+  m_Version: 2

--- a/client/Assets/Prefabs/Managers/VFXGraphPrewarmer.prefab.meta
+++ b/client/Assets/Prefabs/Managers/VFXGraphPrewarmer.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 8fba8c5aea162c246b9eb5f55a261340
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/client/Assets/ScriptableObjects/VFXGraphHolder.asset
+++ b/client/Assets/ScriptableObjects/VFXGraphHolder.asset
@@ -1,0 +1,37 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 005ecccad93da5445b84a77cc2aa116e, type: 3}
+  m_Name: VFXGraphHolder
+  m_EditorClassIdentifier: 
+  vfx_graphs:
+  - {fileID: 6456135847170302225, guid: 631506308d6444a64bdf22b92b368124, type: 3}
+  - {fileID: 7017218312715976829, guid: 4fc144b63d69c4811ae710e9c3a2b968, type: 3}
+  - {fileID: 5874514398963917427, guid: 41f068eeafa39494387cc12a55059719, type: 3}
+  - {fileID: 6541413364609946126, guid: fe6b9e135161b2c47a9a7dfa963c4fcf, type: 3}
+  - {fileID: 6541413364609946126, guid: c0efded4863521745a61fe4983432e3b, type: 3}
+  - {fileID: 2701273495037961085, guid: 9086438c602644ffd9be0f34ce5b9599, type: 3}
+  - {fileID: 2701273495037961085, guid: 9e36bbbd2fa1454419478278da9e8e3a, type: 3}
+  - {fileID: 5842915733016833727, guid: a21b6ad8bdb6b0a48bab30fd0e50d921, type: 3}
+  - {fileID: 8886168713142207525, guid: eeb98e2ecdff49e4783051d2af45806b, type: 3}
+  - {fileID: 8886168713142207525, guid: 4952c4739b8852c4d84ecfd4ec1ed89e, type: 3}
+  - {fileID: 3268232265063840701, guid: 12bd9afa0c8f06344aa774eb50898975, type: 3}
+  - {fileID: 695258524620621366, guid: ef9e760d3a8966f4793c4995dadde0f0, type: 3}
+  - {fileID: 7096130188477378498, guid: 1b0acc3ce1538554e9b68d31470cbb8e, type: 3}
+  - {fileID: 8937093405017515387, guid: 28e88f4ccef6c8c4d99d368b7a702270, type: 3}
+  - {fileID: 1371067997947001578, guid: 31cd86e2ec9638145a9cf5f4567e213d, type: 3}
+  - {fileID: 7479955308286163599, guid: ca307a77acfef4440bd3dd21afaad6dd, type: 3}
+  - {fileID: 5020121509897920601, guid: aeea652475ff4564cbd57dc3f655dab4, type: 3}
+  - {fileID: 6888337135511328701, guid: c6d40a21094cb0a4d8ad3feda127dd41, type: 3}
+  - {fileID: 6888337135511328701, guid: 8304582cda4a3b443acf5eed8deaa160, type: 3}
+  - {fileID: 6888337135511328701, guid: c5b9cf6f7da90a048bf82339301b5f38, type: 3}
+  - {fileID: 5269552939558784490, guid: 531becbb295d1e24180a44a03e0d81f0, type: 3}
+  - {fileID: 7408538769109093279, guid: 9b3089641f7b7aa49afe1ba4dcaeadef, type: 3}

--- a/client/Assets/ScriptableObjects/VFXGraphHolder.asset.meta
+++ b/client/Assets/ScriptableObjects/VFXGraphHolder.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 919b8848c8dc8834585d3f32c2d34579
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/client/Assets/Scripts/Utils/VFXGraphHolder.cs
+++ b/client/Assets/Scripts/Utils/VFXGraphHolder.cs
@@ -1,0 +1,9 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+[CreateAssetMenu(fileName = "VFXGraphHolder", menuName = "ScriptableObject/VFXGraphHolder")]
+public class VFXGraphHolder : ScriptableObject
+{
+    [SerializeField] public GameObject[] vfx_graphs = null;
+}

--- a/client/Assets/Scripts/Utils/VFXGraphHolder.cs.meta
+++ b/client/Assets/Scripts/Utils/VFXGraphHolder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 005ecccad93da5445b84a77cc2aa116e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/client/Assets/Scripts/Utils/VFXGraphPrewarmer.cs
+++ b/client/Assets/Scripts/Utils/VFXGraphPrewarmer.cs
@@ -1,0 +1,43 @@
+using System.Collections;
+using UnityEngine;
+
+public class VFXGraphPrewarmer : MonoBehaviour
+{
+    [SerializeField] private VFXGraphHolder vfx_graph_holder = null;
+    [SerializeField] private Transform spawn_root = null;
+    [SerializeField] private Camera camera = null;
+    [SerializeField] private int start_frames_delay = 5;
+    [SerializeField] private int interval_frames_delay = 2;
+
+    void Start()
+    {
+        StartCoroutine(spawnQueue());
+    }
+
+    IEnumerator spawnQueue()
+    {
+        float start_time = Time.time;
+        GameObject cached_game_object = null;
+        camera.enabled = true;
+
+        yield return waitForFrames(start_frames_delay);
+        foreach(GameObject vfx_graph in vfx_graph_holder.vfx_graphs)
+        {
+            if (vfx_graph == null)
+                continue;
+
+            cached_game_object = Instantiate(vfx_graph, spawn_root);
+            yield return waitForFrames(interval_frames_delay);
+            Destroy( cached_game_object );
+        }
+        camera.enabled = false;
+
+        Debug.Log($"VFX Graph prewarming took {Time.time - start_time}s");
+    }
+
+    IEnumerator waitForFrames( int frame_count )
+    {
+        for(int i = 0; i < frame_count; i++ )
+            yield return null;
+    }
+}

--- a/client/Assets/Scripts/Utils/VFXGraphPrewarmer.cs.meta
+++ b/client/Assets/Scripts/Utils/VFXGraphPrewarmer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 39d2632c095b01b43b2f981bc9e3daaf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Motivation

Added VFX Graph prewarmer - a tool for compiling shaders from VFX Graphs at the beginning of the scene to avoid freezes during gameplay.

## Summary of changes

 - added VFX Graph prewarmer

## How has this been tested?

To test the tool, perform usual gameplay. At the beginning of the Battle scene, the console log will show information about shader compilation time.

## Test additions / changes

List tests added/updated.

## Checklist
- [ ] I have tested the changes locally.
- [ ] I self-reviewed the changes on GitHub, line by line.
- [ ] Tests have been added/updated.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] I have tested the changes in another devices.
  - [ ] Tested in iOS.
  - [ ] Tested in Android.
