### PR TITLE
Fix portraits resolution

### DIFF
--- a/client/Assets/Prefabs/Camera/CameraUI.prefab
+++ b/client/Assets/Prefabs/Camera/CameraUI.prefab
@@ -136,8 +136,8 @@ RectTransform:
   m_Children:
   - {fileID: 1558749284821676708}
   - {fileID: 1531348733418472702}
-  - {fileID: 6579593011659604296}
   - {fileID: 1776069428583422584}
+  - {fileID: 6579593011659604296}
   m_Father: {fileID: 4776084761794064}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -3234,7 +3234,7 @@ RectTransform:
   - {fileID: 7244019777335054706}
   - {fileID: 4694456534383602725}
   m_Father: {fileID: 224931852115754924}
-  m_RootOrder: 2
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -3928,7 +3928,7 @@ RectTransform:
   - {fileID: 6972989582973935364}
   - {fileID: 1413022483004132574}
   m_Father: {fileID: 224931852115754924}
-  m_RootOrder: 3
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}

--- a/client/Assets/Prefabs/UI/BattlePlayerCardContainer.prefab
+++ b/client/Assets/Prefabs/UI/BattlePlayerCardContainer.prefab
@@ -27,7 +27,7 @@ RectTransform:
   m_GameObject: {fileID: 580273047187176251}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.535, y: 0.535, z: 0.535}
+  m_LocalScale: {x: 0.5, y: 0.5, z: 0.5}
   m_ConstrainProportionsScale: 1
   m_Children: []
   m_Father: {fileID: 6850519976614240660}
@@ -35,8 +35,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 2.1, y: 5}
-  m_SizeDelta: {x: 413, y: 514.49146}
+  m_AnchoredPosition: {x: 2.100006, y: 5}
+  m_SizeDelta: {x: 442, y: 513.161}
   m_Pivot: {x: 0, y: 0}
 --- !u!222 &502312972282558866
 CanvasRenderer:
@@ -66,7 +66,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 790b13ddb1435423989fde5f5a321942, type: 3}
+  m_Sprite: {fileID: 0}
   m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1


### PR DESCRIPTION
Closes #1712 

## Motivation

The portraits were a bit stretched in the Y axis

## Summary of changes

<img width="1641" alt="Screenshot 2024-04-26 at 14 51 20" src="https://github.com/lambdaclass/curse_of_mirra/assets/82987608/a78ef534-8ca3-4876-8082-81ed98a4b4a0">
<img width="1641" alt="Screenshot 2024-04-26 at 14 51 50" src="https://github.com/lambdaclass/curse_of_mirra/assets/82987608/3f45793b-8b04-46af-b335-5b521b057ca0">
<img width="1641" alt="Screenshot 2024-04-26 at 14 53 26" src="https://github.com/lambdaclass/curse_of_mirra/assets/82987608/40ff0222-e17a-4e64-960b-12b74afef436">

Use the issues reference images to compare if the issue was solved

## Checklist
- [x] I have tested the changes locally.
- [x] I self-reviewed the changes on GitHub, line by line.
- [ ] Tests have been added/updated.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [x] I have tested the changes in another devices.
  - [ ] Tested in iOS.
  - [x] Tested in Android.
