### PR TITLE
[GH-1734] Fix skill name and descriptions in char info

### DIFF
--- a/client/Assets/ScriptableObjects/Skills/H4ck/H4ck_Denial.asset
+++ b/client/Assets/ScriptableObjects/Skills/H4ck/H4ck_Denial.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: H4ck_Denial
   m_EditorClassIdentifier: Assembly-CSharp::SkillInfo
   name: DENIAL OF SERVICE
-  description: Target your enemies from far away and make it rain
+  description: Target your enemies from far away and make it rain.
   inputType: 1
   skillSetType: 1
   angle: 0

--- a/client/Assets/ScriptableObjects/Skills/H4ck/H4ck_Denial.asset
+++ b/client/Assets/ScriptableObjects/Skills/H4ck/H4ck_Denial.asset
@@ -13,8 +13,7 @@ MonoBehaviour:
   m_Name: H4ck_Denial
   m_EditorClassIdentifier: Assembly-CSharp::SkillInfo
   name: DENIAL OF SERVICE
-  description: "Throws 15 projectiles \u201Cmachine-gun\u201D style, in a cone with
-    randomized direction."
+  description: Target your enemies from far away and make it rain
   inputType: 1
   skillSetType: 1
   angle: 0

--- a/client/Assets/ScriptableObjects/Skills/H4ck/H4ck_Flash.asset
+++ b/client/Assets/ScriptableObjects/Skills/H4ck/H4ck_Flash.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: H4ck_Flash
   m_EditorClassIdentifier: Assembly-CSharp::SkillInfo
   name: FLASH
-  description: Perform a dash that deals damage to enemies in its path.
+  description: Perform a quick dash avoiding enemies along the way.
   inputType: 2
   skillSetType: 2
   angle: 0

--- a/client/Assets/ScriptableObjects/Skills/Muflus/Muflus_Leap.asset
+++ b/client/Assets/ScriptableObjects/Skills/Muflus/Muflus_Leap.asset
@@ -13,8 +13,8 @@ MonoBehaviour:
   m_Name: Muflus_Leap
   m_EditorClassIdentifier: Assembly-CSharp::SkillInfo
   name: LEAP
-  description: Leaps to a target, stomping the ground dealing damage to nearby targets
-    and leaving a slowing field.
+  description: Leaps to a target, stomping the ground and dealing damage to nearby
+    enemies upon landing.
   inputType: 1
   skillSetType: 1
   angle: 0

--- a/client/Assets/ScriptableObjects/Skills/Muflus/Muflus_Rampage.asset
+++ b/client/Assets/ScriptableObjects/Skills/Muflus/Muflus_Rampage.asset
@@ -13,8 +13,7 @@ MonoBehaviour:
   m_Name: Muflus_Rampage
   m_EditorClassIdentifier: Assembly-CSharp::SkillInfo
   name: RAMPAGE
-  description: Muflus dashes in a rolling-boulder fashion, dealing damage to enemies
-    in its path.
+  description: Muflus dashes fiercely in a rolling-boulder fashion.
   inputType: 2
   skillSetType: 2
   angle: 0

--- a/client/Assets/ScriptableObjects/Skills/Uma/Uma_Sneak.asset
+++ b/client/Assets/ScriptableObjects/Skills/Uma/Uma_Sneak.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: Uma_Sneak
   m_EditorClassIdentifier: Assembly-CSharp::SkillInfo
   name: SNEAK
-  description: 'Uma performs a quick dash becoming invisible. '
+  description: Uma swiftly dashes forward in her soul form.
   inputType: 2
   skillSetType: 2
   angle: 0

--- a/client/Assets/ScriptableObjects/Skills/Uma/Uma_Veil.asset
+++ b/client/Assets/ScriptableObjects/Skills/Uma/Uma_Veil.asset
@@ -13,8 +13,8 @@ MonoBehaviour:
   m_Name: Uma_Veil
   m_EditorClassIdentifier: Assembly-CSharp::SkillInfo
   name: VEIL OF RADIANCE
-  description: "Channels her lamp becoming invisible, emits 360\xB0 magic nova that
-    damages and blinds opponents."
+  description: "Channels her lamp becoming invisible, emmiting a 360\xB0 magic nova
+    that damages opponents nearby."
   inputType: 0
   skillSetType: 1
   angle: 0

--- a/client/Assets/ScriptableObjects/Skills/Valtimer/Valtimer_Antimatter.asset
+++ b/client/Assets/ScriptableObjects/Skills/Valtimer/Valtimer_Antimatter.asset
@@ -13,8 +13,7 @@ MonoBehaviour:
   m_Name: Valtimer_Antimatter
   m_EditorClassIdentifier: Assembly-CSharp::SkillInfo
   name: ANTIMATTER
-  description: Mid-range projectile attack with acceptable damage and splash damage
-    on hi.
+  description: Mid-range projectile attack with noticeable splash damage on hit.
   inputType: 2
   skillSetType: 0
   angle: 45

--- a/client/Assets/ScriptableObjects/Skills/Valtimer/Valtimer_Singularity.asset
+++ b/client/Assets/ScriptableObjects/Skills/Valtimer/Valtimer_Singularity.asset
@@ -13,8 +13,7 @@ MonoBehaviour:
   m_Name: Valtimer_Singularity
   m_EditorClassIdentifier: Assembly-CSharp::SkillInfo
   name: SINGULARITY
-  description: Create a black hole in a specific location for 5 seconds which attracts
-    enemy players and deals damage.
+  description: Create a black hole that pulls enemies into it while dealing damage.
   inputType: 1
   skillSetType: 1
   angle: 0

--- a/client/Assets/ScriptableObjects/Skills/Valtimer/Valtimer_Warp.asset
+++ b/client/Assets/ScriptableObjects/Skills/Valtimer/Valtimer_Warp.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: cfa431e235fe84c1b89716712b674a78, type: 3}
   m_Name: Valtimer_Warp
   m_EditorClassIdentifier: Assembly-CSharp::SkillInfo
-  name: WRAP
+  name: WARP
   description: Teleport-like dash, opening a black hole and then warping to it.
   inputType: 1
   skillSetType: 2


### PR DESCRIPTION
Closes #1734 

## Motivation

Some skill descriptions were outdated and didn't reflect the current skill of the characters. Added a full stop to the end of the descriptors that didn't have. Also, there was a typo in Valtimer's Dash title (wrap instead of warp)
## Summary of changes
Reviewed skill descriptor and title for all characters.

## How has this been tested?
Build and go to char info screen and review all characters. **I did not try it in Android, it is important that while testing the PR someone does**


## Checklist
- [x] I have tested the changes locally.
- [x] I self-reviewed the changes on GitHub, line by line.
- [ ] Tests have been added/updated.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [x] I have tested the changes in another devices.
  - [x] Tested in iOS.
  - [ ] Tested in Android.
