### PR TITLE
[GH-1738] Updated PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,16 +12,13 @@ List changes in code.
 
 Describe the steps you performed to test this PR.
 
-## Test additions / changes
-
-List tests added/updated.
-
 ## Checklist
 - [ ] I have tested the changes locally.
+- [ ] I have tested the whole game after applying the changes, not only the affected areas.
 - [ ] I self-reviewed the changes on GitHub, line by line.
-- [ ] Tests have been added/updated.
-- [ ] This change requires new documentation.
-  - [ ] Documentation has been added/updated.
 - [ ] I have tested the changes in another devices.
   - [ ] Tested in iOS.
   - [ ] Tested in Android.
+- [ ] This change requires new documentation.
+  - [ ] Documentation has been added/updated.
+


### PR DESCRIPTION
Closes #1738 

## Motivation

The current PR template is too big and asks for things we don't use. This causes developers to ignore the whole template making it counter productive.

## Summary of changes

Removed section "Test additions / changes", remove tasks for adding tests, added task for testing the whole game, moved to the bottom task of documentation because it is optional

## Checklist
- [x] I have tested the changes locally.
- [x] I self-reviewed the changes on GitHub, line by line.
- [ ] Tests have been added/updated.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.
- [ ] I have tested the changes in another devices.
  - [ ] Tested in iOS.
  - [ ] Tested in Android.
