### PR TITLE
Add giant and fake item to client

### DIFF
--- a/client/Assets/Prefabs/Camera/CameraUI.prefab
+++ b/client/Assets/Prefabs/Camera/CameraUI.prefab
@@ -15602,6 +15602,7 @@ MonoBehaviour:
   myrrasBlessing: {fileID: 21300000, guid: 15a391ce6dff4475291e63535fe9d897, type: 3}
   goldenClock: {fileID: 21300000, guid: 8216d114089c24acd97341b8372e3772, type: 3}
   magicBoots: {fileID: 21300000, guid: 318b77bccbd88431e84cee3aa43be682, type: 3}
+  giant: {fileID: 21300000, guid: 3a8c49535c5fe49459499996f29cb35a, type: 3}
   inventoryImage: {fileID: 158492541652231486}
 --- !u!1 &4707298941903163517
 GameObject:

--- a/client/Assets/Prefabs/Camera/CameraUI.prefab
+++ b/client/Assets/Prefabs/Camera/CameraUI.prefab
@@ -15603,6 +15603,7 @@ MonoBehaviour:
   goldenClock: {fileID: 21300000, guid: 8216d114089c24acd97341b8372e3772, type: 3}
   magicBoots: {fileID: 21300000, guid: 318b77bccbd88431e84cee3aa43be682, type: 3}
   giant: {fileID: 21300000, guid: 3a8c49535c5fe49459499996f29cb35a, type: 3}
+  fakeItem: {fileID: 21300000, guid: e2254038a42c24597894939c8698a0a8, type: 3}
   inventoryImage: {fileID: 158492541652231486}
 --- !u!1 &4707298941903163517
 GameObject:

--- a/client/Assets/Scripts/CharacterFeedbacks.cs
+++ b/client/Assets/Scripts/CharacterFeedbacks.cs
@@ -143,6 +143,8 @@ public class CharacterFeedbacks : MonoBehaviour
                 return magicBootsVFX;
             case "golden_clock_effect":
                 return goldenClockVFX;
+            case "giant_effect":
+                return goldenClockVFX;
             default:
                 return null;
         }

--- a/client/Assets/Scripts/InventoryUI.cs
+++ b/client/Assets/Scripts/InventoryUI.cs
@@ -23,6 +23,7 @@ public class InventoryUI : MonoBehaviour
     public Sprite goldenClock;
     public Sprite magicBoots;
     public Sprite giant;
+    public Sprite fakeItem;
 
     [SerializeField]
     Image inventoryImage;
@@ -130,6 +131,8 @@ public class InventoryUI : MonoBehaviour
                 return magicBoots;
             case "giant":
                 return giant;
+            case "fake_item":
+                return fakeItem;
             default:
                 return null;
         }

--- a/client/Assets/Scripts/InventoryUI.cs
+++ b/client/Assets/Scripts/InventoryUI.cs
@@ -22,6 +22,7 @@ public class InventoryUI : MonoBehaviour
     public Sprite myrrasBlessing;
     public Sprite goldenClock;
     public Sprite magicBoots;
+    public Sprite giant;
 
     [SerializeField]
     Image inventoryImage;
@@ -127,6 +128,8 @@ public class InventoryUI : MonoBehaviour
                 return goldenClock;
             case "magic_boots":
                 return magicBoots;
+            case "giant":
+                return giant;
             default:
                 return null;
         }

--- a/client/Assets/Scripts/Loot.cs
+++ b/client/Assets/Scripts/Loot.cs
@@ -131,6 +131,8 @@ public class Loot : MonoBehaviour
                 return "LootHealth";
             case "mirra_blessing":
                 return "LootHealth";
+            case "giant":
+                return "LootHealth";
             default:
                 throw new ArgumentException(String.Format("no type for `{0}`", name));
         }

--- a/client/Assets/Scripts/Loot.cs
+++ b/client/Assets/Scripts/Loot.cs
@@ -133,6 +133,8 @@ public class Loot : MonoBehaviour
                 return "LootHealth";
             case "giant":
                 return "LootHealth";
+            case "fake_item":
+                return "LootHealth";
             default:
                 throw new ArgumentException(String.Format("no type for `{0}`", name));
         }

--- a/client/Assets/VFX-Tools/Pingle_Tools/PingleCheatPanelItems.cs
+++ b/client/Assets/VFX-Tools/Pingle_Tools/PingleCheatPanelItems.cs
@@ -90,6 +90,11 @@ public class PingleCheatPanelItems : MonoBehaviour
         {
             activateItemVFX(golden_clock_vfx);
         }
+
+        if ( GUI.Button(new Rect( 400, 100, 80, 80 ), "fake_item") )
+        {
+            activateItemVFX(golden_clock_vfx);
+        }
     }
 
     private void activateItemVFX(GameObject vfx)

--- a/client/Assets/VFX-Tools/Pingle_Tools/PingleCheatPanelItems.cs
+++ b/client/Assets/VFX-Tools/Pingle_Tools/PingleCheatPanelItems.cs
@@ -85,16 +85,6 @@ public class PingleCheatPanelItems : MonoBehaviour
         {
             activateItemVFX(magic_boots_vfx);
         }
-
-        if ( GUI.Button(new Rect( 400, 100, 80, 80 ), "giant") )
-        {
-            activateItemVFX(golden_clock_vfx);
-        }
-
-        if ( GUI.Button(new Rect( 400, 100, 80, 80 ), "fake_item") )
-        {
-            activateItemVFX(golden_clock_vfx);
-        }
     }
 
     private void activateItemVFX(GameObject vfx)

--- a/client/Assets/VFX-Tools/Pingle_Tools/PingleCheatPanelItems.cs
+++ b/client/Assets/VFX-Tools/Pingle_Tools/PingleCheatPanelItems.cs
@@ -85,6 +85,11 @@ public class PingleCheatPanelItems : MonoBehaviour
         {
             activateItemVFX(magic_boots_vfx);
         }
+
+        if ( GUI.Button(new Rect( 400, 100, 80, 80 ), "giant") )
+        {
+            activateItemVFX(golden_clock_vfx);
+        }
     }
 
     private void activateItemVFX(GameObject vfx)


### PR DESCRIPTION
Back [PR](https://github.com/lambdaclass/mirra_backend/pull/577)

## Motivation

There are two new items to be added:
- giant
- fake-item

giant has a bottle icon
fake item has a box icon

they both have the golden clock vfx until the final ones are done. I could also leave them without any vfx but it should be decided by our PM or TLs

## Summary of changes

This PR adds them to the client 

## How has this been tested?

run locally the backend and delete all items except for the one that you want to test, to ensure the item picked is the one desired

## Checklist
- [x] I have tested the changes locally.
- [x] I have tested the whole game after applying the changes, not only the affected areas.
- [x] I self-reviewed the changes on GitHub, line by line.
- [ ] I have tested the changes in another devices.
  - [ ] Tested in iOS.
  - [ ] Tested in Android.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.

