### PR TITLE
Fix movement block in battle init

### DIFF
--- a/client/Assets/Scripts/UI/PrepareForBattleAnimations.cs
+++ b/client/Assets/Scripts/UI/PrepareForBattleAnimations.cs
@@ -62,7 +62,7 @@ public class PrepareForBattleAnimations : MonoBehaviour
         yield return new WaitUntil(
             () => GameServerConnectionManager.Instance.players.Count > 0 && loadingComplete
         );
-                player = Utils.GetPlayer(GameServerConnectionManager.Instance.playerId);
+        player = Utils.GetPlayer(GameServerConnectionManager.Instance.playerId);
         Position playerBackEndPosition = Utils
             .GetGamePlayer(GameServerConnectionManager.Instance.playerId)
             .Position;
@@ -83,6 +83,7 @@ public class PrepareForBattleAnimations : MonoBehaviour
         yield return new WaitForSeconds(SURVIVE_DURATION);
         gameObject.SetActive(false);
         battleScreen.GetComponent<CanvasGroup>().blocksRaycasts = true;
+        print("You can move now");
     }
 
     IEnumerator LoadingAnimation()
@@ -195,8 +196,8 @@ public class PrepareForBattleAnimations : MonoBehaviour
             .Append(countDown.transform.DOScale(originalCountdownScale + 0.2f, .5f))
             .SetLoops(-1, LoopType.Yoyo)
             .SetEase(Ease.Linear);
-                    TIME_UNTIL_GAME_STARTS =
-            (int)(GameServerConnectionManager.Instance.gameCountdown / 1000) - 1;
+        TIME_UNTIL_GAME_STARTS =
+(int)(GameServerConnectionManager.Instance.gameCountdown / 1000);
         for (int i = 0; i < TIME_UNTIL_GAME_STARTS; i++)
         {
             countDown.text = (TIME_UNTIL_GAME_STARTS - i).ToString();

--- a/client/Assets/Scripts/UI/PrepareForBattleAnimations.cs
+++ b/client/Assets/Scripts/UI/PrepareForBattleAnimations.cs
@@ -83,7 +83,6 @@ public class PrepareForBattleAnimations : MonoBehaviour
         yield return new WaitForSeconds(SURVIVE_DURATION);
         gameObject.SetActive(false);
         battleScreen.GetComponent<CanvasGroup>().blocksRaycasts = true;
-        print("You can move now");
     }
 
     IEnumerator LoadingAnimation()


### PR DESCRIPTION
## Motivation

Fix first movement.

## Summary of changes

Change time freezing player movement.

## How has this been tested?

Start a game check if you can move in the moment the Battle init animation disappear. 

## Checklist
- [x] I have tested the changes locally.
- [x] I have tested the whole game after applying the changes, not only the affected areas.
- [x] I self-reviewed the changes on GitHub, line by line.
- [x] I have tested the changes in another devices.
  - [ ] Tested in iOS.
  - [x] Tested in Android.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.

