### PR TITLE
Fix killed by zone indicators

### DIFF
--- a/client/Assets/Scripts/UI/EndGame/EndGameManager.cs
+++ b/client/Assets/Scripts/UI/EndGame/EndGameManager.cs
@@ -35,7 +35,7 @@ public class EndGameManager : MonoBehaviour
 
     private const int WINNER_POS = 1;
     private const int SECOND_PLACE_POS = 2;
-    private const string ZONE_ID = "0";
+    private const ulong ZONE_ID = 9999;
     CustomCharacter player;
 
     void OnEnable()
@@ -59,7 +59,7 @@ public class EndGameManager : MonoBehaviour
         }
     }
 
-    public void ShowWinner() 
+    public void ShowWinner()
     {
         winnerContainer.GetComponent<CanvasGroup>().DOFade(1, 1f);
         winnerNameText.text = GameServerConnectionManager.Instance.winnerPlayer.Item1.Name;
@@ -129,7 +129,7 @@ public class EndGameManager : MonoBehaviour
 
     void MaybeShowDefeaterName()
     {
-        if (KillFeedManager.instance.GetMyKillerId().ToString() == ZONE_ID)
+        if (KillFeedManager.instance.GetMyKillerId() == ZONE_ID)
         {
             defeaterPlayerName.gameObject.SetActive(false);
         }
@@ -141,7 +141,7 @@ public class EndGameManager : MonoBehaviour
 
     private Sprite GetDefeaterSprite()
     {
-        if (KillFeedManager.instance.GetMyKillerId().ToString() == ZONE_ID)
+        if (KillFeedManager.instance.GetMyKillerId() == ZONE_ID)
         {
             return KillFeedManager.instance.zoneIcon;
         }

--- a/client/Assets/Scripts/UI/KillFeedManager.cs
+++ b/client/Assets/Scripts/UI/KillFeedManager.cs
@@ -21,7 +21,7 @@ public class KillFeedManager : MonoBehaviour
 
     private ulong currentTrackedPlayer;
     private bool currentTrackedPlayerIsSet = false;
-    private const ulong ZONE_ID = 0;
+    private const ulong ZONE_ID = 9999;
 
     void Awake()
     {
@@ -65,7 +65,8 @@ public class KillFeedManager : MonoBehaviour
 
     public void Update()
     {
-        if(GameServerConnectionManager.Instance.gamePlayers?.Count() > 0 && currentTrackedPlayerIsSet == false){
+        if (GameServerConnectionManager.Instance.gamePlayers?.Count() > 0 && currentTrackedPlayerIsSet == false)
+        {
             currentTrackedPlayer = GameServerConnectionManager.Instance.playerId;
             currentTrackedPlayerIsSet = true;
         }
@@ -90,8 +91,16 @@ public class KillFeedManager : MonoBehaviour
             ulong killerPlayerId = killEvent.KillerId;
 
             string deathPlayerName = Utils.GetGamePlayer(deathPlayerId).Name;
-            string killerPlayerName = Utils.GetGamePlayer(killerPlayerId).Name;
+            string killerPlayerName;
+            if (killerPlayerId == ZONE_ID)
+            {
+                killerPlayerName = ZONE_ID.ToString();
+            }
+            else
+            {
+                killerPlayerName = Utils.GetGamePlayer(killerPlayerId).Name;
 
+            }
             Sprite killerIcon = GetUIIcon(killEvent.KillerId);
             Sprite killedIcon = GetUIIcon(killEvent.VictimId);
 
@@ -100,28 +109,34 @@ public class KillFeedManager : MonoBehaviour
             Destroy(item, 3.0f);
         }
 
-        if(Utils.GetGamePlayer(currentTrackedPlayer)?.Player.Health <= 0 && killEvent == null){
+        if (Utils.GetGamePlayer(currentTrackedPlayer)?.Player.Health <= 0 && killEvent == null)
+        {
             currentTrackedPlayer = ZONE_ID;
         }
     }
 
-    public ulong GetSaveKillderId(){
+    public ulong GetSaveKillderId()
+    {
         return this.saveKillerId;
     }
 
-    public void SetSaveKillderId(ulong newSaveKillderId){
+    public void SetSaveKillderId(ulong newSaveKillderId)
+    {
         this.saveKillerId = newSaveKillderId;
     }
 
-    public ulong GetMyKillerId(){
+    public ulong GetMyKillerId()
+    {
         return this.myKillerId;
     }
 
-    public ulong GetCurrentTrackedPlayer(){
+    public ulong GetCurrentTrackedPlayer()
+    {
         return this.currentTrackedPlayer;
     }
 
-    public void SetCurrentTrackedPlayer(ulong newCurrentTrackedPlayer){
+    public void SetCurrentTrackedPlayer(ulong newCurrentTrackedPlayer)
+    {
         this.currentTrackedPlayer = newCurrentTrackedPlayer;
     }
 }


### PR DESCRIPTION
Backend PR https://github.com/lambdaclass/mirra_backend/pull/587

## Motivation

There was no indicators in the killfeed when a player was killed by the zone

## Summary of changes

This PR fixes that

## How has this been tested?

block bots movements to ensure they die by the zone

back repo
in bot manager > game_socket_handler
comment out lines 29 and 30

## Checklist
- [x] I have tested the changes locally.
- [x] I have tested the whole game after applying the changes, not only the affected areas.
- [x] I self-reviewed the changes on GitHub, line by line.
- [x] I have tested the changes in another devices.
  - [ ] Tested in iOS.
  - [x] Tested in Android.
- [ ] This change requires new documentation.
  - [ ] Documentation has been added/updated.

